### PR TITLE
fix: prevent Start Server button race condition

### DIFF
--- a/vllm_playground/static/js/app.js
+++ b/vllm_playground/static/js/app.js
@@ -8,33 +8,34 @@ class VLLMWebUI {
         this.chatHistory = [];
         this.serverRunning = false;
         this.serverReady = false;  // Track if server startup is complete
+        this.serverStarting = false;  // Track if server start is in progress
         this.healthCheckStarted = false;  // Track if health check polling is active
         this.autoScroll = true;
         this.benchmarkRunning = false;
         this.benchmarkPollInterval = null;
-        
+
         // Current vLLM config
         this.currentConfig = null;
-        
+
         // Resize state
         this.isResizing = false;
         this.currentResizer = null;
         this.resizeDirection = null;
-        
+
         // Template edit timeouts
         this.stopTokensEditTimeout = null;
         this.chatTemplateEditTimeout = null;
-        
+
         // Tool calling state
         this.tools = [];  // Array of tool definitions
         this.editingToolIndex = -1;  // Index of tool being edited, -1 for new tool
-        
+
         // Theme state
         this.currentTheme = localStorage.getItem('vllm-theme') || 'dark';
-        
+
         // GuideLLM state
         this.guidellmAvailable = false;
-        
+
         // MCP (Model Context Protocol) state
         this.mcpAvailable = false;
         this.mcpConfigs = [];           // All configured MCP servers
@@ -43,7 +44,7 @@ class VLLMWebUI {
         this.mcpTools = [];             // Tools from selected servers
         this.mcpPresets = [];           // Built-in presets
         this.mcpDisabledTools = new Set(); // Disabled tools (server:toolName format) - all enabled by default
-        
+
         this.init();
     }
 
@@ -56,7 +57,7 @@ class VLLMWebUI {
             hfToken: document.getElementById('hf-token'),
             host: document.getElementById('host'),
             port: document.getElementById('port'),
-            
+
             // Model Source Toggle
             modelSourceHub: document.getElementById('model-source-hub'),
             modelSourceLocal: document.getElementById('model-source-local'),
@@ -80,7 +81,7 @@ class VLLMWebUI {
             validationIcon: document.getElementById('validation-icon'),
             validationMessage: document.getElementById('validation-message'),
             localModelInfo: document.getElementById('local-model-info'),
-            
+
             // CPU/GPU Mode
             modeCpu: document.getElementById('mode-cpu'),
             modeGpu: document.getElementById('mode-gpu'),
@@ -88,7 +89,7 @@ class VLLMWebUI {
             modeGpuLabel: document.getElementById('mode-gpu-label'),
             modeHelpText: document.getElementById('mode-help-text'),
             cpuSettings: document.getElementById('cpu-settings'),
-            
+
             // Run mode elements
             runModeSubprocess: document.getElementById('run-mode-subprocess'),
             runModeContainer: document.getElementById('run-mode-container'),
@@ -96,16 +97,16 @@ class VLLMWebUI {
             runModeContainerLabel: document.getElementById('run-mode-container-label'),
             runModeHelpText: document.getElementById('run-mode-help-text'),
             gpuSettings: document.getElementById('gpu-settings'),
-            
+
             // GPU settings
             tensorParallel: document.getElementById('tensor-parallel'),
             gpuMemory: document.getElementById('gpu-memory'),
             gpuDevice: document.getElementById('gpu-device'),
-            
+
             // CPU settings
             cpuKvcache: document.getElementById('cpu-kvcache'),
             cpuThreads: document.getElementById('cpu-threads'),
-            
+
             dtype: document.getElementById('dtype'),
             dtypeHelpText: document.getElementById('dtype-help-text'),
             maxModelLen: document.getElementById('max-model-len'),
@@ -114,17 +115,17 @@ class VLLMWebUI {
             enableToolCalling: document.getElementById('enable-tool-calling'),
             toolCallParser: document.getElementById('tool-call-parser'),
             toolParserGroup: document.getElementById('tool-parser-group'),
-            
+
             // Template Settings
             templateSettingsToggle: document.getElementById('template-settings-toggle'),
             templateSettingsContent: document.getElementById('template-settings-content'),
             chatTemplate: document.getElementById('chat-template'),
             stopTokens: document.getElementById('stop-tokens'),
-            
+
             // Command Preview
             commandText: document.getElementById('command-text'),
             copyCommandBtn: document.getElementById('copy-command-btn'),
-            
+
             // Buttons
             startBtn: document.getElementById('start-btn'),
             stopBtn: document.getElementById('stop-btn'),
@@ -135,7 +136,7 @@ class VLLMWebUI {
             logsRowToggle: document.getElementById('logs-row-toggle'),
             logsRow: document.getElementById('logs-row'),
             logsRowContent: document.getElementById('logs-row-content'),
-            
+
             // Chat
             chatContainer: document.getElementById('chat-container'),
             chatInput: document.getElementById('chat-input'),
@@ -146,16 +147,16 @@ class VLLMWebUI {
             maxTokens: document.getElementById('max-tokens'),
             tempValue: document.getElementById('temp-value'),
             tokensValue: document.getElementById('tokens-value'),
-            
+
             // Logs
             logsContainer: document.getElementById('logs-container'),
             autoScrollCheckbox: document.getElementById('auto-scroll'),
-            
+
             // Status
             statusDot: document.getElementById('status-dot'),
             statusText: document.getElementById('status-text'),
             uptime: document.getElementById('uptime'),
-            
+
             // Benchmark
             runBenchmarkBtn: document.getElementById('run-benchmark-btn'),
             stopBenchmarkBtn: document.getElementById('stop-benchmark-btn'),
@@ -182,7 +183,7 @@ class VLLMWebUI {
             progressFill: document.getElementById('progress-fill'),
             progressStatus: document.getElementById('progress-status'),
             progressPercent: document.getElementById('progress-percent'),
-            
+
             // Toolbar Icon Buttons
             toolbarSettings: document.getElementById('toolbar-settings'),
             toolbarPrompt: document.getElementById('toolbar-prompt'),
@@ -190,7 +191,7 @@ class VLLMWebUI {
             toolbarTools: document.getElementById('toolbar-tools'),
             toolbarMcp: document.getElementById('toolbar-mcp'),
             toolbarRag: document.getElementById('toolbar-rag'),
-            
+
             // Inline Panels
             panelSettings: document.getElementById('panel-settings'),
             panelPrompt: document.getElementById('panel-prompt'),
@@ -198,7 +199,7 @@ class VLLMWebUI {
             panelTools: document.getElementById('panel-tools'),
             panelMcp: document.getElementById('panel-mcp'),
             panelRag: document.getElementById('panel-rag'),
-            
+
             // Structured Outputs elements
             structuredEnabled: document.getElementById('structured-enabled'),
             structuredOptions: document.getElementById('structured-options'),
@@ -207,10 +208,10 @@ class VLLMWebUI {
             structuredJsonName: document.getElementById('structured-json-name'),
             structuredJsonSchema: document.getElementById('structured-json-schema'),
             structuredGrammar: document.getElementById('structured-grammar'),
-            
+
             // Tools count
             toolsCount: document.getElementById('tools-count'),
-            
+
             // Theme toggle
             themeToggle: document.getElementById('theme-toggle'),
             toolsCountBadge: document.getElementById('tools-count-badge'),
@@ -241,57 +242,57 @@ class VLLMWebUI {
 
         // Attach event listeners
         this.attachListeners();
-        
+
         // Initialize view switching
         this.initViewSwitching();
-        
+
         // Initialize theme
         this.initTheme();
-        
+
         // Initialize resize functionality
         this.initResize();
-        
+
         // Initialize compute mode (CPU is default)
         this.toggleComputeMode();
-        
+
         // Initialize run mode (Subprocess is default)
         this.toggleRunMode();
-        
+
         // Initialize model source (HF Hub is default)
         this.toggleModelSource();
-        
+
         // Update command preview initially
         this.updateCommandPreview();
-        
+
         // Initialize chat template for default model (silent mode - no notification)
         this.updateTemplateForModel(true);
-        
+
         // NOTE: Benchmark command preview is initialized by GuideLLM module
-        
+
         // Check feature availability (also initializes GuideLLM and MCP modules)
         this.checkFeatureAvailability();
-        
+
         // Connect WebSocket for logs
         this.connectWebSocket();
-        
+
         // Start status polling
         this.pollStatus();
         setInterval(() => this.pollStatus(), 1000);
-        
+
         // Add GPU status refresh button listener
         document.getElementById('gpu-status-refresh').addEventListener('click', () => {
             this.fetchGpuStatus();
         });
-        
+
         // Tool Calling event listeners
         this.initToolCalling();
     }
-    
+
     // ============ View Switching ============
     initViewSwitching() {
         this.currentView = 'vllm-server';
         this.navCollapsed = false;
-        
+
         // Get nav items
         const navItems = document.querySelectorAll('.nav-item');
         navItems.forEach(item => {
@@ -300,13 +301,13 @@ class VLLMWebUI {
                 this.switchView(viewId);
             });
         });
-        
+
         // Collapse button
         const collapseBtn = document.getElementById('nav-collapse-btn');
         if (collapseBtn) {
             collapseBtn.addEventListener('click', () => this.toggleNavSidebar());
         }
-        
+
         // Resize handle for sidebar
         const resizeHandle = document.getElementById('nav-resize-handle');
         if (resizeHandle) {
@@ -315,14 +316,14 @@ class VLLMWebUI {
             document.addEventListener('mouseup', () => this.stopNavResize());
         }
     }
-    
+
     toggleNavSidebar() {
         const sidebar = document.getElementById('nav-sidebar');
         const resizeHandle = document.getElementById('nav-resize-handle');
         const appContainer = document.querySelector('.app-container');
-        
+
         this.navCollapsed = !this.navCollapsed;
-        
+
         if (this.navCollapsed) {
             sidebar.classList.add('collapsed');
             sidebar.style.width = '60px';
@@ -335,35 +336,35 @@ class VLLMWebUI {
             if (appContainer) appContainer.style.marginLeft = '255px';
         }
     }
-    
+
     startNavResize(e) {
         e.preventDefault();
         this.isNavResizing = true;
         this.navResizeStartX = e.clientX;
-        
+
         const sidebar = document.getElementById('nav-sidebar');
         this.navResizeStartWidth = sidebar.offsetWidth;
-        
+
         const resizeHandle = document.getElementById('nav-resize-handle');
         if (resizeHandle) resizeHandle.classList.add('active');
-        
+
         document.body.style.cursor = 'ew-resize';
         document.body.style.userSelect = 'none';
     }
-    
+
     navResize(e) {
         if (!this.isNavResizing) return;
-        
+
         const deltaX = e.clientX - this.navResizeStartX;
         let newWidth = this.navResizeStartWidth + deltaX;
-        
+
         // Clamp width between 60 and 300
         newWidth = Math.max(60, Math.min(300, newWidth));
-        
+
         const sidebar = document.getElementById('nav-sidebar');
         const resizeHandle = document.getElementById('nav-resize-handle');
         const appContainer = document.querySelector('.app-container');
-        
+
         // Auto-collapse if width is small enough
         if (newWidth <= 80) {
             sidebar.classList.add('collapsed');
@@ -372,42 +373,42 @@ class VLLMWebUI {
             sidebar.classList.remove('collapsed');
             this.navCollapsed = false;
         }
-        
+
         sidebar.style.width = `${newWidth}px`;
         if (resizeHandle) resizeHandle.style.left = `${newWidth}px`;
         if (appContainer) appContainer.style.marginLeft = `${newWidth}px`;
     }
-    
+
     stopNavResize() {
         if (!this.isNavResizing) return;
-        
+
         this.isNavResizing = false;
-        
+
         const resizeHandle = document.getElementById('nav-resize-handle');
         if (resizeHandle) resizeHandle.classList.remove('active');
-        
+
         document.body.style.cursor = '';
         document.body.style.userSelect = '';
     }
-    
+
     switchView(viewId) {
         // Update nav items
         document.querySelectorAll('.nav-item').forEach(item => {
             item.classList.toggle('active', item.dataset.view === viewId);
         });
-        
+
         // Update view content
         document.querySelectorAll('.view-content').forEach(view => {
             view.classList.remove('active');
             view.style.display = 'none';
         });
-        
+
         const targetView = document.getElementById(`${viewId}-view`);
         if (targetView) {
             targetView.classList.add('active');
             targetView.style.display = 'block';
         }
-        
+
         // Update header title
         const viewTitle = document.getElementById('view-title');
         if (viewTitle) {
@@ -429,15 +430,15 @@ class VLLMWebUI {
                     viewTitle.textContent = viewId;
             }
         }
-        
+
         this.currentView = viewId;
     }
-    
+
     // ============ Theme Toggle ============
     initTheme() {
         // Apply saved theme on load
         this.applyTheme(this.currentTheme);
-        
+
         // Theme toggle button listener
         if (this.elements.themeToggle) {
             this.elements.themeToggle.addEventListener('click', () => {
@@ -445,11 +446,11 @@ class VLLMWebUI {
             });
         }
     }
-    
+
     applyTheme(theme) {
         const icon = this.elements.themeToggle?.querySelector('.theme-icon');
         const label = this.elements.themeToggle?.querySelector('.theme-label');
-        
+
         if (theme === 'light') {
             document.documentElement.setAttribute('data-theme', 'light');
             if (icon) icon.textContent = '◑';
@@ -467,33 +468,33 @@ class VLLMWebUI {
         }
         this.currentTheme = theme;
     }
-    
+
     toggleTheme() {
         const newTheme = this.currentTheme === 'dark' ? 'light' : 'dark';
         this.applyTheme(newTheme);
         localStorage.setItem('vllm-theme', newTheme);
         this.showNotification(`Switched to ${newTheme} mode`, 'info');
     }
-    
+
     // NOTE: updateBenchmarkServerStatus is injected by GuideLLM module
 
     initToolCalling() {
         // Initialize popover system
         this.initPopovers();
-        
+
         // Initialize structured outputs
         this.initStructuredOutputs();
-        
+
         // Add tool button
         if (this.elements.addToolBtn) {
             this.elements.addToolBtn.addEventListener('click', () => this.openToolEditor());
         }
-        
+
         // Clear all tools
         if (this.elements.clearToolsBtn) {
             this.elements.clearToolsBtn.addEventListener('click', () => this.clearAllTools());
         }
-        
+
         // Tool editor modal
         if (this.elements.toolEditorClose) {
             this.elements.toolEditorClose.addEventListener('click', () => this.closeToolEditor());
@@ -504,17 +505,17 @@ class VLLMWebUI {
         if (this.elements.toolEditorSave) {
             this.elements.toolEditorSave.addEventListener('click', () => this.saveTool());
         }
-        
+
         // Add parameter button
         if (this.elements.addParamBtn) {
             this.elements.addParamBtn.addEventListener('click', () => this.addParameter());
         }
-        
+
         // Tool preset buttons
         document.querySelectorAll('.tool-preset-btn').forEach(btn => {
             btn.addEventListener('click', () => this.loadToolPreset(btn.dataset.preset));
         });
-        
+
         // Close modal on backdrop click
         if (this.elements.toolEditorModal) {
             this.elements.toolEditorModal.addEventListener('click', (e) => {
@@ -523,16 +524,16 @@ class VLLMWebUI {
                 }
             });
         }
-        
+
         // Initialize current parameters array for form
         this.currentParams = [];
     }
-    
+
     // ============ Inline Panels System ============
     initPopovers() {
         // Track which panels are open
         this.openPanels = new Set();
-        
+
         // Toolbar icon button click handlers - toggle their respective panels
         const toolbarButtons = [
             { btn: this.elements.toolbarSettings, panel: this.elements.panelSettings, id: 'settings' },
@@ -542,7 +543,7 @@ class VLLMWebUI {
             { btn: this.elements.toolbarMcp, panel: this.elements.panelMcp, id: 'mcp' },
             { btn: this.elements.toolbarRag, panel: this.elements.panelRag, id: 'rag' }
         ];
-        
+
         toolbarButtons.forEach(({ btn, panel, id }) => {
             if (btn && panel) {
                 btn.addEventListener('click', () => {
@@ -550,7 +551,7 @@ class VLLMWebUI {
                 });
             }
         });
-        
+
         // Close button handlers for all panels
         document.querySelectorAll('.inline-panel-close').forEach(closeBtn => {
             closeBtn.addEventListener('click', () => {
@@ -560,13 +561,13 @@ class VLLMWebUI {
                 }
             });
         });
-        
+
         // Temperature and max tokens sync (slider <-> input)
         const tempSlider = this.elements.temperature;
         const tempInput = document.getElementById('temp-value');
         const tokensSlider = this.elements.maxTokens;
         const tokensInput = document.getElementById('tokens-value');
-        
+
         if (tempSlider && tempInput) {
             tempSlider.addEventListener('input', () => {
                 tempInput.value = tempSlider.value;
@@ -575,7 +576,7 @@ class VLLMWebUI {
                 tempSlider.value = tempInput.value;
             });
         }
-        
+
         if (tokensSlider && tokensInput) {
             tokensSlider.addEventListener('input', () => {
                 tokensInput.value = tokensSlider.value;
@@ -584,7 +585,7 @@ class VLLMWebUI {
                 tokensSlider.value = tokensInput.value;
             });
         }
-        
+
         // Clear system prompt button
         const clearPromptBtn = document.getElementById('clear-system-prompt-btn');
         if (clearPromptBtn) {
@@ -595,7 +596,7 @@ class VLLMWebUI {
                 }
             });
         }
-        
+
         // System prompt template selector
         const promptTemplateSelect = document.getElementById('system-prompt-template');
         if (promptTemplateSelect) {
@@ -608,7 +609,7 @@ class VLLMWebUI {
                 promptTemplateSelect.value = ''; // Reset to show "Templates"
             });
         }
-        
+
         // Add change listeners to all settings inputs for real-time indicator updates
         const settingsPanel = document.getElementById('panel-settings');
         if (settingsPanel) {
@@ -616,13 +617,13 @@ class VLLMWebUI {
                 input.addEventListener('change', () => this.updateModifiedIndicators());
             });
         }
-        
+
         // System prompt text change
         if (this.elements.systemPrompt) {
             this.elements.systemPrompt.addEventListener('input', () => this.updateModifiedIndicators());
         }
     }
-    
+
     getSystemPromptTemplate(type) {
         const templates = {
             default: "You are a helpful assistant.",
@@ -636,7 +637,7 @@ class VLLMWebUI {
         };
         return templates[type] || '';
     }
-    
+
     togglePanel(id, btnEl, panelEl) {
         if (this.openPanels.has(id)) {
             // Close if already open
@@ -650,7 +651,7 @@ class VLLMWebUI {
             this.openPanels.add(id);
         }
     }
-    
+
     closePanel(id) {
         const panel = document.getElementById(`panel-${id}`);
         const btn = document.getElementById(`toolbar-${id}`);
@@ -660,12 +661,12 @@ class VLLMWebUI {
         // Update modified indicators when panel closes
         this.updateModifiedIndicators();
     }
-    
+
     closeAllPanels() {
         const panels = ['settings', 'prompt', 'structured', 'tools', 'mcp', 'rag'];
         panels.forEach(id => this.closePanel(id));
     }
-    
+
     // Check if any settings are modified from defaults and show indicator dots
     updateModifiedIndicators() {
         // Default values - only track key settings to avoid false positives
@@ -674,20 +675,20 @@ class VLLMWebUI {
             maxTokens: 256
         };
         const defaultSystemPrompt = "You are a helpful assistant.";
-        
+
         // Settings panel - only check temperature and max tokens
         const settingsBtn = document.getElementById('toolbar-settings');
         if (settingsBtn) {
             const temp = parseFloat(this.elements.temperature?.value) || 0.7;
             const maxTokens = parseInt(this.elements.maxTokens?.value) || 256;
-            
+
             const isModified = (
                 Math.abs(temp - defaults.temperature) > 0.01 ||
                 maxTokens !== defaults.maxTokens
             );
             settingsBtn.classList.toggle('modified', isModified);
         }
-        
+
         // System prompt - check if text differs from default (empty is also considered modified)
         const promptBtn = document.getElementById('toolbar-prompt');
         if (promptBtn) {
@@ -695,21 +696,21 @@ class VLLMWebUI {
             const isModified = currentPrompt !== defaultSystemPrompt;
             promptBtn.classList.toggle('modified', isModified);
         }
-        
+
         // Structured outputs - check if enabled
         const structuredBtn = document.getElementById('toolbar-structured');
         if (structuredBtn) {
             const isEnabled = this.elements.structuredEnabled?.checked || false;
             structuredBtn.classList.toggle('modified', isEnabled);
         }
-        
+
         // Tool calling - check if any tools are defined
         const toolsBtn = document.getElementById('toolbar-tools');
         if (toolsBtn) {
             const hasTools = (this.tools?.length || 0) > 0;
             toolsBtn.classList.toggle('modified', hasTools);
         }
-        
+
         // MCP - check if MCP is enabled in chat with selected servers
         const mcpBtn = document.getElementById('toolbar-mcp');
         if (mcpBtn) {
@@ -717,14 +718,14 @@ class VLLMWebUI {
             mcpBtn.classList.toggle('modified', mcpActive);
         }
     }
-    
+
     updateToolsBadge() {
         const count = this.tools ? this.tools.length : 0;
         if (this.elements.toolsCount) {
             this.elements.toolsCount.textContent = count;
         }
     }
-    
+
     updateStructuredBadge() {
         if (this.elements.structuredBadge) {
             if (this.elements.structuredEnabled && this.elements.structuredEnabled.checked) {
@@ -735,7 +736,7 @@ class VLLMWebUI {
             }
         }
     }
-    
+
     // ============ Structured Outputs ============
     initStructuredOutputs() {
         this.structuredOutputType = 'choice';
@@ -748,7 +749,7 @@ class VLLMWebUI {
             jsonSchemaName: 'response',
             grammar: ''
         };
-        
+
         // Enable/disable toggle
         if (this.elements.structuredEnabled) {
             this.elements.structuredEnabled.addEventListener('change', () => {
@@ -762,18 +763,18 @@ class VLLMWebUI {
                 this.updateModifiedIndicators();
             });
         }
-        
+
         // Output type buttons
         document.querySelectorAll('.output-type-btn').forEach(btn => {
             btn.addEventListener('click', () => {
                 // Update active button
                 document.querySelectorAll('.output-type-btn').forEach(b => b.classList.remove('active'));
                 btn.classList.add('active');
-                
+
                 const type = btn.dataset.type;
                 this.structuredOutputType = type;
                 this.structuredOutputConfig.type = type;
-                
+
                 // Show/hide config sections
                 document.querySelectorAll('.structured-config').forEach(config => {
                     config.style.display = 'none';
@@ -782,11 +783,11 @@ class VLLMWebUI {
                 if (configEl) {
                     configEl.style.display = 'block';
                 }
-                
+
                 this.updateStructuredBadge();
             });
         });
-        
+
         // Structured output presets
         document.querySelectorAll('.structured-preset-btn').forEach(btn => {
             btn.addEventListener('click', () => {
@@ -794,19 +795,19 @@ class VLLMWebUI {
             });
         });
     }
-    
+
     loadStructuredPreset(preset) {
         const presets = {
             // Choice presets
             sentiment: { type: 'choice', value: 'positive, negative, neutral' },
             yesno: { type: 'choice', value: 'yes, no' },
             rating: { type: 'choice', value: '1, 2, 3, 4, 5' },
-            
+
             // Regex presets
             email: { type: 'regex', value: '\\w+@\\w+\\.\\w+' },
             phone: { type: 'regex', value: '\\d{3}-\\d{3}-\\d{4}' },
             date: { type: 'regex', value: '\\d{4}-\\d{2}-\\d{2}' },
-            
+
             // JSON Schema presets
             person: {
                 type: 'json',
@@ -848,7 +849,7 @@ class VLLMWebUI {
                     required: ['success']
                 }, null, 2)
             },
-            
+
             // Grammar presets
             sql: {
                 type: 'grammar',
@@ -868,10 +869,10 @@ factor ::= number | "(" expression ")"
 number ::= [0-9]+`
             }
         };
-        
+
         const p = presets[preset];
         if (!p) return;
-        
+
         if (p.type === 'choice' && this.elements.structuredChoices) {
             this.elements.structuredChoices.value = p.value;
         } else if (p.type === 'regex' && this.elements.structuredRegex) {
@@ -883,27 +884,27 @@ number ::= [0-9]+`
             this.elements.structuredGrammar.value = p.value;
         }
     }
-    
+
     getStructuredOutputsForRequest() {
         if (!this.structuredOutputConfig.enabled) {
             return null;
         }
-        
+
         const type = this.structuredOutputConfig.type;
-        
+
         if (type === 'choice') {
             const choicesStr = this.elements.structuredChoices?.value || '';
             const choices = choicesStr.split(',').map(c => c.trim()).filter(c => c);
             if (choices.length === 0) return null;
             return { structured_outputs: { choice: choices } };
         }
-        
+
         if (type === 'regex') {
             const regex = this.elements.structuredRegex?.value?.trim();
             if (!regex) return null;
             return { structured_outputs: { regex: regex } };
         }
-        
+
         if (type === 'json') {
             const schemaStr = this.elements.structuredJsonSchema?.value?.trim();
             const schemaName = this.elements.structuredJsonName?.value?.trim() || 'response';
@@ -925,13 +926,13 @@ number ::= [0-9]+`
                 return null;
             }
         }
-        
+
         if (type === 'grammar') {
             const grammar = this.elements.structuredGrammar?.value?.trim();
             if (!grammar) return null;
             return { structured_outputs: { grammar: grammar } };
         }
-        
+
         return null;
     }
 
@@ -939,23 +940,23 @@ number ::= [0-9]+`
         // Server control
         this.elements.startBtn.addEventListener('click', () => this.startServer());
         this.elements.stopBtn.addEventListener('click', () => this.stopServer());
-        
+
         // CPU/GPU mode toggle
         this.elements.modeCpu.addEventListener('change', () => this.toggleComputeMode());
         this.elements.modeGpu.addEventListener('change', () => this.toggleComputeMode());
-        
+
         // Run mode toggle
         this.elements.runModeSubprocess.addEventListener('change', () => this.toggleRunMode());
         this.elements.runModeContainer.addEventListener('change', () => this.toggleRunMode());
-        
+
         // Model Source toggle
         this.elements.modelSourceHub.addEventListener('change', () => this.toggleModelSource());
         this.elements.modelSourceLocal.addEventListener('change', () => this.toggleModelSource());
-        
+
         // Local model path validation and browse
         this.elements.browseFolderBtn.addEventListener('click', () => this.browseForFolder());
         this.elements.validatePathBtn.addEventListener('click', () => this.validateLocalModelPath());
-        
+
         // Community Recipes modal
         if (this.elements.browseRecipesBtn) {
             this.elements.browseRecipesBtn.addEventListener('click', () => this.openRecipesModal());
@@ -979,7 +980,7 @@ number ::= [0-9]+`
         if (this.elements.syncRecipesBtn) {
             this.elements.syncRecipesBtn.addEventListener('click', () => this.syncRecipesFromGitHub());
         }
-        
+
         // Optional: validate on blur (can be removed if you want manual-only validation)
         this.elements.localModelPath.addEventListener('blur', () => {
             // Auto-validate only if path is not empty
@@ -987,12 +988,12 @@ number ::= [0-9]+`
                 this.validateLocalModelPath();
             }
         });
-        
+
         // Clear validation when user starts typing
         this.elements.localModelPath.addEventListener('input', () => {
             this.clearLocalModelValidation();
         });
-        
+
         // Chat
         this.elements.sendBtn.addEventListener('click', () => this.sendMessage());
         this.elements.chatInput.addEventListener('keydown', (e) => {
@@ -1007,7 +1008,7 @@ number ::= [0-9]+`
         });
         this.elements.clearChatBtn.addEventListener('click', () => this.clearChat());
         this.elements.clearSystemPromptBtn.addEventListener('click', () => this.clearSystemPrompt());
-        
+
         // Message templates
         this.elements.messageTemplates.addEventListener('change', (e) => {
             if (e.target.value) {
@@ -1017,13 +1018,13 @@ number ::= [0-9]+`
                 e.target.value = '';
             }
         });
-        
+
         // Logs
         this.elements.clearLogsBtn.addEventListener('click', () => this.clearLogs());
         this.elements.autoScrollCheckbox.addEventListener('change', (e) => {
             this.autoScroll = e.target.checked;
         });
-        
+
         // Save logs button
         if (this.elements.saveLogsBtn) {
             this.elements.saveLogsBtn.addEventListener('click', (e) => {
@@ -1031,7 +1032,7 @@ number ::= [0-9]+`
                 this.saveLogs();
             });
         }
-        
+
         // Logs row toggle (collapsible)
         if (this.elements.logsRowToggle) {
             this.elements.logsRowToggle.addEventListener('click', (e) => {
@@ -1040,7 +1041,7 @@ number ::= [0-9]+`
                 this.toggleLogsRow();
             });
         }
-        
+
         // Generation parameters - bidirectional sync between slider and input
         this.elements.temperature.addEventListener('input', (e) => {
             this.elements.tempValue.value = e.target.value;
@@ -1059,7 +1060,7 @@ number ::= [0-9]+`
             e.target.value = val;
             this.elements.temperature.value = val;
         });
-        
+
         this.elements.maxTokens.addEventListener('input', (e) => {
             this.elements.tokensValue.value = e.target.value;
         });
@@ -1077,7 +1078,7 @@ number ::= [0-9]+`
             e.target.value = val;
             this.elements.maxTokens.value = val;
         });
-        
+
         // Command preview - update when any config changes
         const configElements = [
             this.elements.modelSelect,
@@ -1098,23 +1099,23 @@ number ::= [0-9]+`
             this.elements.enableToolCalling,
             this.elements.toolCallParser
         ];
-        
+
         configElements.forEach(element => {
             element.addEventListener('input', () => this.updateCommandPreview());
             element.addEventListener('change', () => this.updateCommandPreview());
         });
-        
+
         // Toggle tool parser visibility based on enable tool calling checkbox
         this.elements.enableToolCalling.addEventListener('change', () => {
             this.updateToolParserVisibility();
         });
         this.updateToolParserVisibility(); // Initial state
-        
+
         // Copy command button
         this.elements.copyCommandBtn.addEventListener('click', () => this.copyCommand());
-        
+
         // NOTE: Benchmark listeners are set up in GuideLLM module (modules/guidellm.js)
-        
+
         // Template Settings
         this.elements.templateSettingsToggle.addEventListener('click', () => this.toggleTemplateSettings());
         this.elements.modelSelect.addEventListener('change', () => {
@@ -1132,28 +1133,28 @@ number ::= [0-9]+`
     connectWebSocket() {
         const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
         const wsUrl = `${protocol}//${window.location.host}/ws/logs`;
-        
+
         this.ws = new WebSocket(wsUrl);
-        
+
         this.ws.onopen = () => {
             this.addLog('WebSocket connected', 'success');
             this.updateStatus('connected', 'Connected');
         };
-        
+
         this.ws.onmessage = (event) => {
             if (event.data) {
                 this.addLog(event.data);
             }
         };
-        
+
         this.ws.onerror = (error) => {
             this.addLog(`WebSocket error: ${error.message}`, 'error');
         };
-        
+
         this.ws.onclose = () => {
             this.addLog('WebSocket disconnected', 'warning');
             this.updateStatus('disconnected', 'Disconnected');
-            
+
             // Attempt to reconnect after 3 seconds
             setTimeout(() => this.connectWebSocket(), 3000);
         };
@@ -1163,59 +1164,59 @@ number ::= [0-9]+`
         try {
             const response = await fetch('/api/features');
             const features = await response.json();
-            
+
             // Log feature availability
             console.log('Feature availability:', features);
-            
+
             // Disable guidellm option if not available
             if (!features.guidellm) {
                 this.elements.benchmarkMethodGuidellm.disabled = true;
                 this.elements.benchmarkMethodGuidellm.parentElement.classList.add('disabled');
                 this.elements.benchmarkMethodGuidellm.parentElement.title = 'GuideLLM not installed. Run: pip install guidellm';
-                
+
                 // Select built-in method instead
                 if (this.elements.benchmarkMethodBuiltin) {
                     this.elements.benchmarkMethodBuiltin.checked = true;
                 }
-                
+
                 console.warn('GuideLLM is not available. Install with: pip install guidellm');
             }
-            
+
             // Handle vLLM availability (for subprocess mode)
             this.vllmInstalled = features.vllm_installed || false;
             this.vllmVersion = features.vllm_version || null;
             this.containerModeAvailable = features.container_mode || false;
             this.updateRunModeAvailability();
-            
+
             // Handle MCP availability
             this.mcpAvailable = features.mcp || false;
             initMCPModule(this);
-            
+
             // Handle GuideLLM availability
             this.guidellmAvailable = features.guidellm || false;
             initGuideLLMModule(this);
-            
+
             // Update container runtime status
             this.updateContainerRuntimeStatus(features.container_runtime, features.container_mode);
-            
+
             // Update version display
             this.updateVersionDisplay(features.version);
-            
+
             // Check hardware capabilities
             await this.checkHardwareCapabilities();
         } catch (error) {
             console.error('Error checking feature availability:', error);
         }
     }
-    
+
     updateContainerRuntimeStatus(runtime, available) {
         const statusEl = document.getElementById('container-runtime-status');
         if (!statusEl) return;
-        
+
         const textEl = statusEl.querySelector('.feature-status-text');
-        
+
         statusEl.classList.remove('available', 'unavailable');
-        
+
         if (available && runtime) {
             statusEl.classList.add('available');
             textEl.textContent = runtime.charAt(0).toUpperCase() + runtime.slice(1);
@@ -1226,25 +1227,25 @@ number ::= [0-9]+`
             statusEl.title = 'No container runtime available (podman/docker not found)';
         }
     }
-    
+
     updateVersionDisplay(version) {
         const versionEl = document.getElementById('nav-version');
         if (!versionEl) return;
-        
+
         if (version) {
             versionEl.textContent = `v${version}`;
             versionEl.title = `vLLM Playground version ${version}`;
         }
     }
-    
+
     async checkHardwareCapabilities() {
         try {
             const response = await fetch('/api/hardware-capabilities');
             const capabilities = await response.json();
-            
+
             // Log hardware capabilities
             console.log('Hardware capabilities:', capabilities);
-            
+
             // Disable GPU option if GPU is not available
             if (!capabilities.gpu_available) {
                 // Disable GPU radio button
@@ -1253,18 +1254,18 @@ number ::= [0-9]+`
                 this.elements.modeGpuLabel.title = 'GPU not available on this system. Requires CUDA-capable GPU and drivers.';
                 this.elements.modeGpuLabel.style.opacity = '0.5';
                 this.elements.modeGpuLabel.style.cursor = 'not-allowed';
-                
+
                 // Force CPU mode
                 this.elements.modeCpu.checked = true;
                 this.toggleComputeMode();
-                
+
                 // Update help text
                 this.elements.modeHelpText.innerHTML = '⚠️ GPU not available - Running in CPU-only mode';
                 this.elements.modeHelpText.style.color = '#f59e0b';
-                
+
                 // Hide GPU status display
                 document.getElementById('gpu-status-display').style.display = 'none';
-                
+
                 console.warn('GPU is not available on this system');
                 this.addLog('[SYSTEM] GPU not detected - GPU mode disabled', 'warning');
             } else {
@@ -1272,10 +1273,10 @@ number ::= [0-9]+`
                 console.log('GPU is available on this system');
                 this.elements.modeHelpText.innerHTML = 'CPU and GPU modes available. GPU recommended for larger models.';
                 this.addLog('[SYSTEM] GPU detected - Both CPU and GPU modes available', 'info');
-                
+
                 // Show GPU status display
                 document.getElementById('gpu-status-display').style.display = 'block';
-                
+
                 // Start GPU status polling
                 this.startGpuStatusPolling();
             }
@@ -1288,9 +1289,11 @@ number ::= [0-9]+`
         try {
             const response = await fetch('/api/status');
             const data = await response.json();
-            
+
             if (data.running) {
                 this.serverRunning = true;
+                this.serverStarting = false;  // Clear starting flag when server is confirmed running
+                this.elements.startBtn.textContent = 'Start Server';  // Reset button text
                 this.currentConfig = data.config;  // Store current config
                 this.updateStatus('running', 'Server Running');
                 this.elements.startBtn.disabled = true;
@@ -1298,12 +1301,12 @@ number ::= [0-9]+`
                 // Only enable send button if server is ready
                 this.elements.sendBtn.disabled = !this.serverReady;
                 this.elements.runBenchmarkBtn.disabled = false;
-                
+
                 // Update send button state only if serverReady (don't remove class unnecessarily)
                 if (this.serverReady) {
                     this.updateSendButtonState();
                 }
-                
+
                 if (data.uptime) {
                     this.elements.uptime.textContent = `(${data.uptime})`;
                 }
@@ -1313,7 +1316,11 @@ number ::= [0-9]+`
                 this.healthCheckStarted = false;  // Reset health check flag
                 this.currentConfig = null;  // Clear config when server stops
                 this.updateStatus('connected', 'Server Stopped');
-                this.elements.startBtn.disabled = false;
+                // Only re-enable Start button if we're not in the middle of starting
+                if (!this.serverStarting) {
+                    this.elements.startBtn.disabled = false;
+                    this.elements.startBtn.textContent = 'Start Server';
+                }
                 this.elements.stopBtn.disabled = true;
                 this.elements.sendBtn.disabled = true;
                 this.elements.sendBtn.classList.remove('btn-ready');
@@ -1328,7 +1335,7 @@ number ::= [0-9]+`
     updateStatus(state, text) {
         this.elements.statusDot.className = `status-dot ${state}`;
         this.elements.statusText.textContent = text;
-        
+
         // Also update nav sidebar status
         const navStatusDot = document.getElementById('nav-status-dot');
         const navStatusText = document.getElementById('nav-status-text');
@@ -1342,7 +1349,7 @@ number ::= [0-9]+`
                 navStatusText.textContent = 'Offline';
             }
         }
-        
+
         // Update benchmark server status if on that view
         if (this.currentView === 'guidellm') {
             this.updateBenchmarkServerStatus();
@@ -1353,10 +1360,10 @@ number ::= [0-9]+`
     startGpuStatusPolling() {
         // Stop any existing polling
         this.stopGpuStatusPolling();
-        
+
         // Initial fetch
         this.fetchGpuStatus();
-        
+
         // Start polling every 5 seconds
         this.gpuStatusInterval = setInterval(() => {
             this.fetchGpuStatus();
@@ -1374,10 +1381,10 @@ number ::= [0-9]+`
         try {
             const refreshIndicator = document.getElementById('gpu-status-refresh');
             refreshIndicator.classList.add('refreshing');
-            
+
             const response = await fetch('/api/gpu-status');
             const data = await response.json();
-            
+
             refreshIndicator.classList.remove('refreshing');
             this.renderGpuStatus(data);
         } catch (error) {
@@ -1389,7 +1396,7 @@ number ::= [0-9]+`
 
     renderGpuStatus(data) {
         const contentElement = document.getElementById('gpu-status-content');
-        
+
         if (!data.gpu_available || !data.gpus || data.gpus.length === 0) {
             contentElement.innerHTML = '<div class="no-gpu">No GPU devices detected</div>';
             return;
@@ -1442,18 +1449,18 @@ number ::= [0-9]+`
 
     toggleComputeMode() {
         const isCpuMode = this.elements.modeCpu.checked;
-        
+
         // Update button active states
         if (isCpuMode) {
             this.elements.modeCpuLabel.classList.add('active');
             this.elements.modeGpuLabel.classList.remove('active');
             this.elements.modeHelpText.textContent = 'CPU mode is recommended for macOS';
             this.elements.dtypeHelpText.textContent = 'BFloat16 recommended for CPU';
-            
+
             // Show CPU settings, hide GPU settings
             this.elements.cpuSettings.style.display = 'block';
             this.elements.gpuSettings.style.display = 'none';
-            
+
             // Set dtype to bfloat16 for CPU
             this.elements.dtype.value = 'bfloat16';
         } else {
@@ -1461,27 +1468,27 @@ number ::= [0-9]+`
             this.elements.modeGpuLabel.classList.add('active');
             this.elements.modeHelpText.textContent = 'GPU mode for CUDA-enabled systems';
             this.elements.dtypeHelpText.textContent = 'Auto recommended for GPU';
-            
+
             // Show GPU settings, hide CPU settings
             this.elements.cpuSettings.style.display = 'none';
             this.elements.gpuSettings.style.display = 'block';
-            
+
             // Set dtype to auto for GPU
             this.elements.dtype.value = 'auto';
         }
-        
+
         // Update command preview
         this.updateCommandPreview();
     }
 
     toggleRunMode() {
         const isSubprocess = this.elements.runModeSubprocess.checked;
-        
+
         // Update button active states
         if (isSubprocess) {
             this.elements.runModeSubprocessLabel.classList.add('active');
             this.elements.runModeContainerLabel.classList.remove('active');
-            
+
             // Check if vLLM is installed
             if (!this.vllmInstalled) {
                 this.elements.runModeHelpText.innerHTML = '<span style="color: var(--error-color);">⚠️ vLLM not installed. Run: pip install vllm</span>';
@@ -1492,23 +1499,23 @@ number ::= [0-9]+`
         } else {
             this.elements.runModeSubprocessLabel.classList.remove('active');
             this.elements.runModeContainerLabel.classList.add('active');
-            
+
             if (!this.containerModeAvailable) {
                 this.elements.runModeHelpText.innerHTML = '<span style="color: var(--error-color);">⚠️ No container runtime (podman/docker) found</span>';
             } else {
                 this.elements.runModeHelpText.textContent = 'Container: Isolated environment (recommended)';
             }
         }
-        
+
         // Update command preview
         this.updateCommandPreview();
     }
-    
+
     updateRunModeAvailability() {
         // Update UI based on what's available
         const subprocessLabel = this.elements.runModeSubprocessLabel;
         const containerLabel = this.elements.runModeContainerLabel;
-        
+
         // Add visual indication for unavailable modes
         if (!this.vllmInstalled) {
             subprocessLabel.classList.add('mode-unavailable');
@@ -1518,7 +1525,7 @@ number ::= [0-9]+`
             const versionText = this.vllmVersion ? `v${this.vllmVersion}` : 'version unknown';
             subprocessLabel.title = `vLLM (${versionText}) installed`;
         }
-        
+
         if (!this.containerModeAvailable) {
             containerLabel.classList.add('mode-unavailable');
             containerLabel.title = 'No container runtime (podman/docker) found';
@@ -1526,61 +1533,61 @@ number ::= [0-9]+`
             containerLabel.classList.remove('mode-unavailable');
             containerLabel.title = 'Container mode available';
         }
-        
+
         // Trigger toggleRunMode to update help text
         this.toggleRunMode();
     }
 
     toggleModelSource() {
         const isLocalModel = this.elements.modelSourceLocal.checked;
-        
+
         // Update button active states
         if (isLocalModel) {
             this.elements.modelSourceHubLabel.classList.remove('active');
             this.elements.modelSourceLocalLabel.classList.add('active');
-            
+
             // Show local model section, hide HF hub section
             this.elements.localModelSection.style.display = 'block';
             this.elements.hubModelSection.style.display = 'none';
         } else {
             this.elements.modelSourceHubLabel.classList.add('active');
             this.elements.modelSourceLocalLabel.classList.remove('active');
-            
+
             // Show HF hub section, hide local model section
             this.elements.localModelSection.style.display = 'none';
             this.elements.hubModelSection.style.display = 'block';
-            
+
             // Clear local model validation
             this.clearLocalModelValidation();
         }
-        
+
         // Update command preview
         this.updateCommandPreview();
     }
 
     async validateLocalModelPath() {
         const path = this.elements.localModelPath.value.trim();
-        
+
         if (!path) {
             return;
         }
-        
+
         // Show validating status
         this.showValidationStatus('validating', 'Validating path...');
-        
+
         try {
             const response = await fetch('/api/models/validate-local', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ path: path })
             });
-            
+
             const result = await response.json();
-            
+
             if (result.valid) {
                 // Show success
                 this.showValidationStatus('valid', '✓ Valid model directory');
-                
+
                 // Update model info display
                 this.updateLocalModelInfo(result.info);
             } else {
@@ -1597,10 +1604,10 @@ number ::= [0-9]+`
     showValidationStatus(type, message) {
         this.elements.localModelValidation.style.display = 'block';
         this.elements.validationMessage.textContent = message;
-        
+
         // Remove existing classes
         this.elements.localModelValidation.classList.remove('valid', 'invalid', 'validating');
-        
+
         // Add appropriate class
         this.elements.localModelValidation.classList.add(type);
     }
@@ -1613,7 +1620,7 @@ number ::= [0-9]+`
     updateLocalModelInfo(info) {
         // Show model info box
         this.elements.localModelInfo.style.display = 'block';
-        
+
         // Use model_name from backend (intelligently extracted)
         // Fallback to extracting from path if not provided (backward compatibility)
         let modelName;
@@ -1624,7 +1631,7 @@ number ::= [0-9]+`
             const pathParts = info.path.split('/');
             modelName = pathParts[pathParts.length - 1];
         }
-        
+
         document.getElementById('info-model-name').textContent = modelName;
         document.getElementById('info-model-type').textContent = info.model_type || 'Unknown';
         document.getElementById('info-model-size').textContent = info.size_mb ? `${info.size_mb} MB` : 'Unknown';
@@ -1643,40 +1650,40 @@ number ::= [0-9]+`
                 const dirHandle = await window.showDirectoryPicker({
                     mode: 'read'
                 });
-                
+
                 // We can't get the absolute path directly from the handle for security reasons
                 // but we can check if it's a valid model directory
-                
+
                 // Check for required files
                 let hasConfig = false;
                 let hasTokenizer = false;
-                
+
                 try {
                     await dirHandle.getFileHandle('config.json');
                     hasConfig = true;
                 } catch (e) {
                     // File doesn't exist
                 }
-                
+
                 try {
                     await dirHandle.getFileHandle('tokenizer_config.json');
                     hasTokenizer = true;
                 } catch (e) {
                     // File doesn't exist
                 }
-                
+
                 if (!hasConfig || !hasTokenizer) {
                     this.showNotification('⚠️ Selected directory is missing required model files (config.json or tokenizer_config.json)', 'error');
                     return;
                 }
-                
+
                 // Show a prompt asking for the absolute path since we can't get it from the API
                 this.showNotification('Directory selected! Please enter the absolute path to this directory.', 'info');
                 this.showNotification('💡 The browser cannot access the full path for security reasons. Please type or paste the absolute path.', 'info');
-                
+
                 // Focus the input so user can type the path
                 this.elements.localModelPath.focus();
-                
+
             } catch (error) {
                 if (error.name !== 'AbortError') {
                     console.error('Directory picker error:', error);
@@ -1697,16 +1704,16 @@ number ::= [0-9]+`
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ path: this.elements.localModelPath.value || '~' })
             });
-            
+
             if (!response.ok) {
                 throw new Error('Backend folder browser not available');
             }
-            
+
             const data = await response.json();
-            
+
             // Create and show a simple folder browser modal
             this.showFolderBrowserModal(data.directories, data.current_path);
-            
+
         } catch (error) {
             console.error('Backend browser error:', error);
             // Show helpful message
@@ -1723,7 +1730,7 @@ number ::= [0-9]+`
     showFolderBrowserModal(directories, currentPath) {
         // Create a simple modal for browsing directories
         // This is a fallback UI when File System Access API is not available
-        
+
         const modal = document.createElement('div');
         modal.style.cssText = `
             position: fixed;
@@ -1737,7 +1744,7 @@ number ::= [0-9]+`
             justify-content: center;
             z-index: 10000;
         `;
-        
+
         const content = document.createElement('div');
         content.style.cssText = `
             background: #1e293b;
@@ -1748,7 +1755,7 @@ number ::= [0-9]+`
             overflow: auto;
             color: #e2e8f0;
         `;
-        
+
         content.innerHTML = `
             <h3 style="margin-top: 0;">Browse Directories</h3>
             <div style="margin-bottom: 16px; padding: 12px; background: #0f172a; border-radius: 6px; font-family: monospace; word-break: break-all;">
@@ -1767,27 +1774,27 @@ number ::= [0-9]+`
                 <button id="browser-cancel-btn" class="btn btn-secondary">Cancel</button>
             </div>
         `;
-        
+
         modal.appendChild(content);
         document.body.appendChild(modal);
-        
+
         // Add event listeners
         document.getElementById('browser-select-btn').addEventListener('click', () => {
             this.elements.localModelPath.value = currentPath;
             document.body.removeChild(modal);
             this.validateLocalModelPath();
         });
-        
+
         document.getElementById('browser-cancel-btn').addEventListener('click', () => {
             document.body.removeChild(modal);
         });
-        
+
         // Navigate to subdirectory on click
         document.querySelectorAll('.folder-item').forEach(item => {
             item.addEventListener('click', async () => {
                 const path = item.getAttribute('data-path');
                 document.body.removeChild(modal);
-                
+
                 // Fetch subdirectory contents
                 try {
                     const response = await fetch('/api/browse-directories', {
@@ -1807,16 +1814,16 @@ number ::= [0-9]+`
     getConfig() {
         // Check if using local model or HF hub
         const isLocalModel = this.elements.modelSourceLocal.checked;
-        
+
         const model = this.elements.customModel.value.trim() || this.elements.modelSelect.value;
         const localModelPath = this.elements.localModelPath.value.trim();
         const maxModelLen = this.elements.maxModelLen.value;
         const isCpuMode = this.elements.modeCpu.checked;
         const hfToken = this.elements.hfToken.value.trim();
-        
+
         // Get run mode (subprocess or container)
         const runMode = document.getElementById('run-mode-subprocess').checked ? 'subprocess' : 'container';
-        
+
         const config = {
             model: model,
             host: this.elements.host.value,
@@ -1832,11 +1839,11 @@ number ::= [0-9]+`
             enable_tool_calling: this.elements.enableToolCalling.checked,
             tool_call_parser: this.elements.toolCallParser.value || null  // null = auto-detect
         };
-        
+
         // Don't send chat template or stop tokens - let vLLM auto-detect them
         // The fields in the UI are for reference/display only
         // Users who need custom templates can set them via server config JSON or API
-        
+
         if (isCpuMode) {
             // CPU-specific settings
             config.cpu_kvcache_space = parseInt(this.elements.cpuKvcache.value);
@@ -1852,37 +1859,37 @@ number ::= [0-9]+`
                 config.gpu_device = gpuDevice;
             }
         }
-        
+
         return config;
     }
 
     async startServer() {
         const config = this.getConfig();
-        
+
         // Check run mode requirements
         if (config.run_mode === 'subprocess' && !this.vllmInstalled) {
             this.showNotification('⚠️ Cannot use Subprocess mode: vLLM is not installed. Please install vLLM (pip install vllm) or switch to Container mode.', 'error');
             this.addLog('❌ Subprocess mode requires vLLM to be installed. Run: pip install vllm', 'error');
             return;
         }
-        
+
         if (config.run_mode === 'container' && !this.containerModeAvailable) {
             this.showNotification('⚠️ Cannot use Container mode: No container runtime found. Please install podman or docker.', 'error');
             this.addLog('❌ Container mode requires podman or docker to be installed.', 'error');
             return;
         }
-        
+
         // Validate local model path if using local model
         if (config.local_model_path) {
             this.addLog('🔍 Validating local model path...', 'info');
-            
+
             // Check if path is provided
             if (!config.local_model_path.trim()) {
                 this.showNotification('⚠️ Please enter a local model path', 'error');
                 this.addLog('❌ Local model path is empty', 'error');
                 return;
             }
-            
+
             // Validate the path before starting server
             try {
                 const validateResponse = await fetch('/api/models/validate-local', {
@@ -1890,15 +1897,15 @@ number ::= [0-9]+`
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ path: config.local_model_path })
                 });
-                
+
                 const validateResult = await validateResponse.json();
-                
+
                 if (!validateResult.valid) {
                     this.showNotification(`⚠️ Invalid model path: ${validateResult.error}`, 'error');
                     this.addLog(`❌ Path validation failed: ${validateResult.error}`, 'error');
                     return;
                 }
-                
+
                 this.addLog(`✓ Local model validated successfully`, 'success');
                 this.addLog(`  Path: ${validateResult.info.path}`, 'info');
                 this.addLog(`  Size: ${validateResult.info.size_mb} MB`, 'info');
@@ -1908,29 +1915,36 @@ number ::= [0-9]+`
                 return;
             }
         }
-        
+
         // Check if gated model requires HF token (frontend validation) - only for HF Hub models
         if (!config.local_model_path) {
             const model = config.model.toLowerCase();
             const isGated = model.includes('meta-llama/') || model.includes('redhatai/llama');
-            
+
             if (isGated && !config.hf_token) {
                 this.showNotification(`⚠️ ${config.model} is a gated model and requires a HuggingFace token!`, 'error');
                 this.addLog(`❌ Gated model requires HF token: ${config.model}`, 'error');
                 return;
             }
         }
-        
-        // Reset ready state
+
+        // Prevent duplicate starts - return early if already starting
+        if (this.serverStarting) {
+            this.showNotification('⚠️ Server is already starting, please wait...', 'warning');
+            return;
+        }
+
+        // Set starting flag and reset ready state
+        this.serverStarting = true;
         this.serverReady = false;
         this.elements.sendBtn.classList.remove('btn-ready');
-        
+
         this.elements.startBtn.disabled = true;
         this.elements.startBtn.textContent = 'Starting...';
-        
+
         // Add immediate log feedback
         this.addLog('🚀 Starting vLLM server...', 'info');
-        
+
         if (config.local_model_path) {
             this.addLog(`Model Source: Local Folder`, 'info');
             this.addLog(`Path: ${config.local_model_path}`, 'info');
@@ -1938,10 +1952,10 @@ number ::= [0-9]+`
             this.addLog(`Model Source: HuggingFace Hub`, 'info');
             this.addLog(`Model: ${config.model}`, 'info');
         }
-        
+
         this.addLog(`Run Mode: ${config.run_mode === 'subprocess' ? 'Subprocess (Direct)' : 'Container (Isolated)'}`, 'info');
         this.addLog(`Compute Mode: ${config.use_cpu ? 'CPU' : 'GPU'}`, 'info');
-        
+
         try {
             const response = await fetch('/api/start', {
                 method: 'POST',
@@ -1950,14 +1964,14 @@ number ::= [0-9]+`
                 },
                 body: JSON.stringify(config)
             });
-            
+
             if (!response.ok) {
                 const error = await response.json();
                 throw new Error(error.detail || 'Failed to start server');
             }
-            
+
             const data = await response.json();
-            
+
             // Log success with appropriate identifier
             if (data.mode === 'container') {
                 this.addLog(`✅ Server started in container mode`, 'success');
@@ -1966,38 +1980,40 @@ number ::= [0-9]+`
                 this.addLog(`✅ Server started in subprocess mode`, 'success');
                 this.addLog(`Process ID: ${data.pid}`, 'info');
             }
-            
+
             this.addLog('⏳ Waiting for server initialization...', 'info');
             this.showNotification('Server started successfully', 'success');
-            
+
         } catch (error) {
             this.addLog(`❌ Failed to start server: ${error.message}`, 'error');
             this.showNotification(`Failed to start: ${error.message}`, 'error');
+            // On failure, clear starting flag and re-enable button
+            this.serverStarting = false;
             this.elements.startBtn.disabled = false;
-        } finally {
             this.elements.startBtn.textContent = 'Start Server';
         }
+        // On success, pollStatus() will detect running state and clear serverStarting flag
     }
 
     async stopServer() {
         this.elements.stopBtn.disabled = true;
         this.elements.stopBtn.textContent = 'Stopping...';
-        
+
         this.addLog('⏹️ Stopping vLLM server...', 'info');
-        
+
         try {
             const response = await fetch('/api/stop', {
                 method: 'POST'
             });
-            
+
             if (!response.ok) {
                 const error = await response.json();
                 throw new Error(error.detail || 'Failed to stop server');
             }
-            
+
             this.addLog('✅ Server stopped successfully', 'success');
             this.showNotification('Server stopped', 'success');
-            
+
         } catch (error) {
             this.addLog(`❌ Failed to stop server: ${error.message}`, 'error');
             this.showNotification(`Failed to stop: ${error.message}`, 'error');
@@ -2009,27 +2025,27 @@ number ::= [0-9]+`
 
     async sendMessage() {
         const message = this.elements.chatInput.value.trim();
-        
+
         if (!message) {
             return;
         }
-        
+
         if (!this.serverRunning) {
             this.showNotification('Please start the server first', 'warning');
             return;
         }
-        
+
         // Add user message to chat
         this.addChatMessage('user', message);
         this.chatHistory.push({role: 'user', content: message});
-        
+
         // Clear input
         this.elements.chatInput.value = '';
-        
+
         // Disable send button
         this.elements.sendBtn.disabled = true;
         this.elements.sendBtn.textContent = 'Generating...';
-        
+
         // Create placeholder for assistant message
         const assistantMessageDiv = this.addChatMessage('assistant', '▌');
         const textSpan = assistantMessageDiv.querySelector('.message-text');
@@ -2037,12 +2053,12 @@ number ::= [0-9]+`
         let startTime = Date.now();
         let firstTokenTime = null;
         let usageData = null;
-        
+
         try {
             // Get current system prompt and prepare messages
             const systemPrompt = this.elements.systemPrompt.value.trim();
             let messagesToSend = [...this.chatHistory];  // Copy chat history
-            
+
             // Prepend system prompt to messages if provided
             // This ensures system prompt is sent with every request dynamically
             if (systemPrompt) {
@@ -2051,16 +2067,16 @@ number ::= [0-9]+`
                     ...this.chatHistory
                 ];
             }
-            
+
             // Don't send stop tokens by default - let vLLM handle them automatically via chat template
             // Stop tokens are only for reference/documentation in the UI
             // Users can still set custom_stop_tokens in the server config if needed
-            
+
             // Get tools configuration - MCP and Custom Tools are SEPARATE
             // MCP takes priority when enabled
             let toolsConfig = { tools: null, tool_choice: null, parallel_tool_calls: null };
             let usingMCPTools = false;
-            
+
             if (this.mcpEnabled && typeof this.getMCPToolsForRequest === 'function') {
                 // MCP is enabled - use MCP tools
                 const mcpTools = this.getMCPToolsForRequest();
@@ -2076,22 +2092,22 @@ number ::= [0-9]+`
                     console.log('Tool names:', mcpTools.map(t => t.function?.name));
                 }
             }
-            
+
             if (!usingMCPTools) {
                 // MCP not enabled or no MCP tools - use custom tools from Tool Calling panel
                 toolsConfig = this.getToolsForRequest();
                 console.log('=== Using Custom Tools ===');
             }
-            
+
             // Build request body
             // Check if tools are being used - use non-streaming for tool calls
             // vLLM streaming has issues with tool_calls data not being sent properly
             const useStreaming = !toolsConfig.tools || toolsConfig.tools.length === 0 || toolsConfig.tool_choice === 'none';
-            
+
             if (!useStreaming) {
                 console.log('🔧 Tools detected - using non-streaming mode for reliable tool call response');
             }
-            
+
             const requestBody = {
                 messages: messagesToSend,  // Send messages with system prompt prepended
                 temperature: parseFloat(this.elements.temperature.value),
@@ -2099,10 +2115,10 @@ number ::= [0-9]+`
                 stream: useStreaming
                 // No stop_tokens - let vLLM handle them automatically
             };
-            
+
             // Store flag for response handling (Phase 2: MCP tool execution)
             this._currentRequestUsingMCP = usingMCPTools;
-            
+
             // Add tools if configured
             console.log('=== sendMessage: toolsConfig ===', toolsConfig);
             if (toolsConfig.tools) {
@@ -2117,14 +2133,14 @@ number ::= [0-9]+`
             } else {
                 console.log('No tools added to request (toolsConfig.tools is null/undefined)');
             }
-            
+
             // Add structured outputs if configured
             const structuredConfig = this.getStructuredOutputsForRequest();
             if (structuredConfig) {
                 Object.assign(requestBody, structuredConfig);
                 console.log('Structured outputs enabled:', structuredConfig);
             }
-            
+
             // Use streaming
             const response = await fetch('/api/chat', {
                 method: 'POST',
@@ -2133,31 +2149,31 @@ number ::= [0-9]+`
                 },
                 body: JSON.stringify(requestBody)
             });
-            
+
             if (!response.ok) {
                 const errorText = await response.text();
                 throw new Error(errorText || 'Failed to send message');
             }
-            
+
             // Handle non-streaming response (used for tool calls)
             if (!useStreaming) {
                 console.log('📥 Processing non-streaming response...');
                 const jsonResponse = await response.json();
                 console.log('📥 Full response:', jsonResponse);
-                
+
                 if (jsonResponse.choices && jsonResponse.choices.length > 0) {
                     const choice = jsonResponse.choices[0];
                     const message = choice.message;
-                    
+
                     if (message && message.tool_calls && message.tool_calls.length > 0) {
                         // Display tool calls (and text content if present)
                         console.log('🔧 Tool calls received:', message.tool_calls);
                         console.log('📝 Message content:', message.content);
                         console.log('📝 Full message object:', JSON.stringify(message, null, 2));
-                        
+
                         // Build HTML with optional text content + tool calls
                         let fullHtml = '';
-                        
+
                         // Show text content if present
                         if (message.content && message.content.trim()) {
                             console.log('📝 Adding text content to display');
@@ -2165,7 +2181,7 @@ number ::= [0-9]+`
                         } else {
                             console.log('📝 No text content to display (null or empty)');
                         }
-                        
+
                         // Use different format for MCP vs custom tools
                         if (this._currentRequestUsingMCP) {
                             // MCP tools - show with Execute/Skip buttons
@@ -2174,10 +2190,10 @@ number ::= [0-9]+`
                             // Custom tools - display only (manual handling)
                             fullHtml += this.formatToolCallMessage(message.tool_calls);
                         }
-                        
+
                         textSpan.innerHTML = fullHtml;
                         assistantMessageDiv.classList.add('tool-call');
-                        
+
                         // Add to chat history (include content if present)
                         this.chatHistory.push({
                             role: 'assistant',
@@ -2193,7 +2209,7 @@ number ::= [0-9]+`
                         textSpan.classList.add('message-text');
                         assistantMessageDiv.classList.add('error');
                     }
-                    
+
                     // Show usage metrics if available
                     if (jsonResponse.usage) {
                         usageData = jsonResponse.usage;
@@ -2204,15 +2220,15 @@ number ::= [0-9]+`
                     textSpan.classList.add('message-text');
                     assistantMessageDiv.classList.add('error');
                 }
-                
+
                 // Calculate and display metrics for non-streaming
                 const endTime = Date.now();
                 const timeTaken = (endTime - startTime) / 1000;
-                
+
                 const promptTokens = usageData?.prompt_tokens || 0;
                 const completionTokens = usageData?.completion_tokens || 0;
                 const totalTokens = usageData?.total_tokens || (promptTokens + completionTokens);
-                
+
                 this.updateChatMetrics({
                     promptTokens: promptTokens,
                     completionTokens: completionTokens,
@@ -2220,55 +2236,55 @@ number ::= [0-9]+`
                     timeTaken: timeTaken,
                     tokensPerSecond: completionTokens > 0 ? (completionTokens / timeTaken).toFixed(2) : 0
                 });
-                
+
                 console.log('Non-streaming response completed');
                 return;
             }
-            
+
             // Read the streaming response
             const reader = response.body.getReader();
             const decoder = new TextDecoder();
-            
+
             console.log('Starting to read streaming response...');
-            
+
             // Track raw response data for debugging tool call failures
             let rawChunks = [];
             let toolsWereRequested = requestBody.tools && requestBody.tools.length > 0;
-            
+
             while (true) {
                 const {done, value} = await reader.read();
-                
+
                 if (done) {
                     console.log('Stream reading complete');
                     break;
                 }
-                
+
                 // Decode the chunk
                 const chunk = decoder.decode(value, {stream: true});
                 const lines = chunk.split('\n');
-                
+
                 for (const line of lines) {
                     if (line.startsWith('data: ')) {
                         const data = line.substring(6).trim();
-                        
+
                         if (data === '[DONE]') {
                             console.log('Received [DONE] signal');
                             break;
                         }
-                        
+
                         try {
                             const parsed = JSON.parse(data);
-                            
+
                             // Store raw chunks for debugging
                             if (toolsWereRequested) {
                                 rawChunks.push(parsed);
                             }
-                            
+
                             if (parsed.choices && parsed.choices.length > 0) {
                                 // Handle OpenAI-compatible chat completions endpoint format
                                 const choice = parsed.choices[0];
                                 let content = null;
-                                
+
                                 // Check for tool calls in delta (streaming)
                                 if (choice.delta && choice.delta.tool_calls) {
                                     // Store tool calls for later processing
@@ -2304,7 +2320,7 @@ number ::= [0-9]+`
                                     this.pendingToolCalls = choice.tool_calls;
                                     textSpan.innerHTML = '🔧 <em>Tool call requested</em>';
                                 }
-                                
+
                                 // Chat completions endpoint format (standard OpenAI format)
                                 if (choice.delta && choice.delta.content) {
                                     content = choice.delta.content;
@@ -2317,29 +2333,29 @@ number ::= [0-9]+`
                                 else if (choice.text !== undefined) {
                                     content = choice.text;
                                 }
-                                
+
                                 if (content) {
                                     // Capture time to first token
                                     if (firstTokenTime === null) {
                                         firstTokenTime = Date.now();
                                         console.log('Time to first token:', (firstTokenTime - startTime) / 1000, 'seconds');
                                     }
-                                    
+
                                     fullText += content;
                                     // Update the message in real-time with cursor
                                     textSpan.textContent = `${fullText}▌`;
-                                    
+
                                     // Auto-scroll to bottom
                                     this.elements.chatContainer.scrollTop = this.elements.chatContainer.scrollHeight;
                                 }
                             }
-                            
+
                             // Capture usage data if available - check both standard and x-* fields
                             if (parsed.usage) {
                                 usageData = parsed.usage;
                                 console.log('Captured usage data:', usageData);
                             }
-                            
+
                             // vLLM may also include metrics in custom fields
                             if (parsed.metrics) {
                                 console.log('Captured metrics:', parsed.metrics);
@@ -2353,7 +2369,7 @@ number ::= [0-9]+`
                     }
                 }
             }
-            
+
             // Debug: Log raw chunks if tools were requested but no tool calls captured
             if (toolsWereRequested && (!this.pendingToolCalls || this.pendingToolCalls.length === 0)) {
                 console.warn('⚠️ Tools were requested but no tool_calls in response. Raw chunks:', rawChunks);
@@ -2362,10 +2378,10 @@ number ::= [0-9]+`
                 console.warn('📋 Full chunk structure (copy this for debugging):');
                 console.warn(JSON.stringify(rawChunks, null, 2));
             }
-            
+
             console.log('Finalizing response, fullText length:', fullText.length);
             console.log('Usage data:', usageData);
-            
+
             // Remove cursor and finalize
             // Check if we have tool calls
             if (this.pendingToolCalls && this.pendingToolCalls.length > 0) {
@@ -2373,17 +2389,17 @@ number ::= [0-9]+`
                 const toolCallsHtml = this.formatToolCallMessage(this.pendingToolCalls);
                 textSpan.innerHTML = toolCallsHtml;
                 assistantMessageDiv.classList.add('tool-call');
-                
+
                 // Add to chat history with tool_calls
                 this.chatHistory.push({
                     role: 'assistant',
                     content: null,
                     tool_calls: this.pendingToolCalls
                 });
-                
+
                 // Clear pending tool calls
                 this.pendingToolCalls = null;
-                
+
                 console.log('Tool calls displayed:', this.chatHistory[this.chatHistory.length - 1].tool_calls);
             } else if (fullText) {
                 // Clean up response:
@@ -2391,20 +2407,20 @@ number ::= [0-9]+`
                 fullText = fullText.replace(/\\r\\n/g, '\n');  // Replace literal \r\n with actual newline
                 fullText = fullText.replace(/\\n/g, '\n');     // Replace literal \n with actual newline
                 fullText = fullText.replace(/\\r/g, '');       // Remove literal \r
-                
+
                 // 2. Trim and limit excessive newlines (4+ → 2)
                 fullText = fullText.replace(/\n{4,}/g, '\n\n').trim();
-                
+
                 // 3. If response is ONLY newlines/whitespace, mark as error
                 if (!fullText || fullText.match(/^[\s\n\r]+$/)) {
                     textSpan.textContent = 'Model generated only whitespace. Try: 1) Clear system prompt, 2) Lower temperature, 3) Different model';
                     assistantMessageDiv.classList.add('error');
-                } 
+                }
                 // 4. Check for malformed tool call patterns in the text
                 // This happens when vLLM's tool parser fails but returns the raw output
                 else if (toolsWereRequested && this.detectMalformedToolCall(fullText)) {
                     console.warn('⚠️ Detected malformed tool call in response text:', fullText);
-                    
+
                     const errorMsg = `⚠️ Tool Parsing Error
 
 The model tried to call a tool but generated malformed JSON that couldn't be parsed.
@@ -2421,11 +2437,11 @@ Suggestions:
 
 Raw output (for debugging):
 ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
-                    
+
                     textSpan.textContent = errorMsg;
                     textSpan.classList.add('message-text');
                     assistantMessageDiv.classList.add('error');
-                    
+
                     // Also log to console for debugging
                     console.error('🔧 MALFORMED TOOL CALL DETECTED:');
                     console.error('  Full text:', fullText);
@@ -2441,19 +2457,19 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     // Tools were sent but model didn't respond properly
                     const toolChoice = requestBody.tool_choice || 'auto';
                     let errorMsg = `⚠️ Tool calling failed (tool_choice: "${toolChoice}")\n\n`;
-                    
+
                     if (rawChunks.length > 0) {
                         // Show what the model actually returned
                         const lastChunk = rawChunks[rawChunks.length - 1];
                         const finishReason = lastChunk?.choices?.[0]?.finish_reason || 'unknown';
                         errorMsg += `Finish reason: ${finishReason}\n`;
-                        
+
                         // Check if there's a partial tool call that wasn't captured
-                        const hasPartialToolCall = rawChunks.some(c => 
-                            c?.choices?.[0]?.delta?.tool_calls || 
+                        const hasPartialToolCall = rawChunks.some(c =>
+                            c?.choices?.[0]?.delta?.tool_calls ||
                             c?.choices?.[0]?.message?.tool_calls
                         );
-                        
+
                         if (finishReason === 'tool_calls') {
                             // Model tried to use tools but we didn't capture the data
                             // This usually means the model generated malformed JSON that vLLM couldn't parse
@@ -2467,7 +2483,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                             errorMsg += `• Use a larger model (8B+ recommended)\n`;
                             errorMsg += `• Try: Llama-3.1-8B-Instruct, Mistral-7B-Instruct\n`;
                             errorMsg += `• Or disable tools (set tool_choice to "none")`;
-                            
+
                             // Log detailed debug info
                             console.error('🔧 TOOL CALL PARSE FAILURE:');
                             console.error('  The model generated finish_reason="tool_calls" but no tool_calls data was returned.');
@@ -2488,7 +2504,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                         errorMsg += `No response chunks received.\n`;
                         errorMsg += `Check server logs for errors.`;
                     }
-                    
+
                     textSpan.textContent = errorMsg;
                     textSpan.classList.add('message-text');  // Add class for proper styling
                     console.error('Tool calling failed. Raw chunks:', rawChunks);
@@ -2498,12 +2514,12 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 }
                 assistantMessageDiv.classList.add('error');
             }
-            
+
             // Calculate and display metrics
             const endTime = Date.now();
             const timeTaken = (endTime - startTime) / 1000; // in seconds
             const timeToFirstToken = firstTokenTime ? (firstTokenTime - startTime) / 1000 : null; // in seconds
-            
+
             // Estimate prompt tokens if not provided (rough estimate: ~4 chars per token)
             const estimatedPromptTokens = usageData?.prompt_tokens || Math.ceil(
                 this.chatHistory
@@ -2511,40 +2527,40 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     .map(msg => msg.content.length)
                     .reduce((a, b) => a + b, 0) / 4
             );
-            
+
             const completionTokens = usageData?.completion_tokens || fullText.split(/\s+/).length;
             const totalTokens = usageData?.total_tokens || (estimatedPromptTokens + completionTokens);
-            
+
             // Extract additional metrics from usage data if available
             // vLLM may provide these under different field names
-            let kvCacheUsage = usageData?.gpu_cache_usage_perc || 
-                                usageData?.kv_cache_usage || 
-                                usageData?.cache_usage;
-            let prefixCacheHitRate = usageData?.prefix_cache_hit_rate || 
-                                      usageData?.cached_tokens_ratio;
-            
+            let kvCacheUsage = usageData?.gpu_cache_usage_perc ||
+                usageData?.kv_cache_usage ||
+                usageData?.cache_usage;
+            let prefixCacheHitRate = usageData?.prefix_cache_hit_rate ||
+                usageData?.cached_tokens_ratio;
+
             console.log('Full usage data:', usageData);
-            
+
             // Wait a moment for vLLM to log stats for this request
             // vLLM logs stats after request completion, so we need to give it time
             console.log('⏳ Waiting 2 seconds for vLLM to log metrics...');
             await new Promise(resolve => setTimeout(resolve, 2000));
-            
+
             // Fetch additional metrics from vLLM's metrics endpoint
             let metricsAge = null;
             try {
                 const metricsResponse = await fetch('/api/vllm/metrics');
                 console.log('Metrics response status:', metricsResponse.status);
-                
+
                 if (metricsResponse.ok) {
                     const vllmMetrics = await metricsResponse.json();
                     console.log('✓ Fetched vLLM metrics:', vllmMetrics);
-                    
+
                     // Check how fresh the metrics are
                     if (vllmMetrics.metrics_age_seconds !== undefined) {
                         metricsAge = vllmMetrics.metrics_age_seconds;
                         console.log(`  → Metrics age: ${metricsAge}s`);
-                        
+
                         // Metrics should be very fresh (< 5 seconds) to be from this request
                         if (metricsAge <= 5) {
                             console.log(`  ✅ Metrics are fresh - likely from this response`);
@@ -2554,7 +2570,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                             console.warn(`  ⚠️ Metrics are ${metricsAge}s old - may not be from this response`);
                         }
                     }
-                    
+
                     // Update metrics if available
                     if (vllmMetrics.kv_cache_usage_perc !== undefined) {
                         console.log('  → Using KV cache usage:', vllmMetrics.kv_cache_usage_perc);
@@ -2562,7 +2578,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     } else {
                         console.log('  → No kv_cache_usage_perc in response');
                     }
-                    
+
                     if (vllmMetrics.prefix_cache_hit_rate !== undefined) {
                         console.log('  → Using prefix cache hit rate:', vllmMetrics.prefix_cache_hit_rate);
                         prefixCacheHitRate = vllmMetrics.prefix_cache_hit_rate;
@@ -2575,7 +2591,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             } catch (e) {
                 console.warn('Could not fetch vLLM metrics:', e);
             }
-            
+
             console.log('Final Metrics:', {
                 promptTokens: estimatedPromptTokens,
                 completionTokens: completionTokens,
@@ -2586,7 +2602,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 prefixCacheHitRate: prefixCacheHitRate,
                 metricsAge: metricsAge
             });
-            
+
             this.updateChatMetrics({
                 promptTokens: estimatedPromptTokens,
                 completionTokens: completionTokens,
@@ -2597,17 +2613,17 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 prefixCacheHitRate: prefixCacheHitRate,
                 metricsAge: metricsAge
             });
-            
+
         } catch (error) {
             console.error('Chat error details:', error);
             this.addLog(`❌ Chat error: ${error.message}`, 'error');
             this.showNotification(`Error: ${error.message}`, 'error');
-            
+
             // Remove the placeholder message
             if (assistantMessageDiv && assistantMessageDiv.parentNode) {
                 assistantMessageDiv.remove();
             }
-            
+
             this.addChatMessage('system', `Error: ${error.message}`);
         } finally {
             console.log('Finally block executed - resetting button');
@@ -2622,7 +2638,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
     addChatMessage(role, content) {
         const messageDiv = document.createElement('div');
         messageDiv.className = `chat-message ${role}`;
-        
+
         // Add avatar for user and assistant messages
         if (role !== 'system') {
             const avatarDiv = document.createElement('div');
@@ -2630,21 +2646,21 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             avatarDiv.textContent = role === 'user' ? 'U' : 'AI';
             messageDiv.appendChild(avatarDiv);
         }
-        
+
         const contentDiv = document.createElement('div');
         contentDiv.className = 'message-content';
-        
+
         const textSpan = document.createElement('span');
         textSpan.className = 'message-text';
         textSpan.textContent = content;
         contentDiv.appendChild(textSpan);
-        
+
         messageDiv.appendChild(contentDiv);
         this.elements.chatContainer.appendChild(messageDiv);
-        
+
         // Auto-scroll
         this.elements.chatContainer.scrollTop = this.elements.chatContainer.scrollHeight;
-        
+
         return messageDiv;
     }
 
@@ -2658,7 +2674,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             </div>
         `;
     }
-    
+
     clearSystemPrompt() {
         this.elements.systemPrompt.value = '';
         this.showNotification('System prompt cleared', 'success');
@@ -2668,15 +2684,15 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         // Check if server startup is complete - look for vLLM-specific ready indicators
         // "Uvicorn running" or "Application startup complete" appear BEFORE model is loaded
         // So we start health check polling when we see these, then confirm with /health endpoint
-        if (message && !this.healthCheckStarted && 
-            (message.includes('Application startup complete') || 
-             message.includes('Uvicorn running') ||
-             message.match(/Application startup complete/i))) {
+        if (message && !this.healthCheckStarted &&
+            (message.includes('Application startup complete') ||
+                message.includes('Uvicorn running') ||
+                message.match(/Application startup complete/i))) {
             console.log('🔄 Uvicorn started, beginning health check polling...');
             this.healthCheckStarted = true;
             this.startHealthCheckPolling();
         }
-        
+
         // Auto-detect log type if not specified
         if (type === 'info' && message) {
             const lowerMsg = message.toLowerCase();
@@ -2688,20 +2704,20 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 type = 'success';
             }
         }
-        
+
         const logEntry = document.createElement('div');
         logEntry.className = `log-entry ${type}`;
-        
+
         const timestamp = new Date().toLocaleTimeString();
         logEntry.textContent = `[${timestamp}] ${message}`;
-        
+
         this.elements.logsContainer.appendChild(logEntry);
-        
+
         // Auto-scroll if enabled
         if (this.autoScroll) {
             this.elements.logsContainer.scrollTop = this.elements.logsContainer.scrollHeight;
         }
-        
+
         // Limit log entries to prevent memory issues
         const maxLogs = 1000;
         const logs = this.elements.logsContainer.querySelectorAll('.log-entry');
@@ -2709,7 +2725,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             logs[0].remove();
         }
     }
-    
+
     updateSendButtonState() {
         // Update Send button appearance when server is ready
         if (this.serverReady && this.serverRunning) {
@@ -2731,19 +2747,19 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         // Poll the vLLM health endpoint to confirm server is truly ready
         const maxAttempts = 60; // 60 attempts * 2 seconds = 2 minutes max
         let attempts = 0;
-        
+
         const checkHealth = async () => {
             if (!this.serverRunning || this.serverReady) {
                 this.healthCheckStarted = false;
                 return;
             }
-            
+
             attempts++;
-            
+
             try {
                 const response = await fetch('/api/vllm/health');
                 const data = await response.json();
-                
+
                 if (data.success && data.status_code === 200) {
                     console.log('🎉 vLLM health check passed! Server is ready.');
                     this.serverReady = true;
@@ -2756,7 +2772,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 // Health check failed, continue polling
                 console.log(`Health check attempt ${attempts}/${maxAttempts} - waiting...`);
             }
-            
+
             if (attempts < maxAttempts && this.serverRunning && !this.serverReady) {
                 setTimeout(checkHealth, 2000); // Check every 2 seconds
             } else {
@@ -2766,7 +2782,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 }
             }
         };
-        
+
         // Start checking after a brief delay
         setTimeout(checkHealth, 1000);
     }
@@ -2780,22 +2796,22 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
     saveLogs() {
         const logsContainer = this.elements.logsContainer;
         if (!logsContainer) return;
-        
+
         // Get all log entries as text
         const logEntries = logsContainer.querySelectorAll('.log-entry');
         let logText = '';
         const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        
+
         logEntries.forEach(entry => {
             const text = entry.textContent || entry.innerText;
             logText += text + '\n';
         });
-        
+
         if (!logText.trim()) {
             this.showNotification('No logs to save', 'warning');
             return;
         }
-        
+
         // Create and download file
         const blob = new Blob([logText], { type: 'text/plain' });
         const url = URL.createObjectURL(blob);
@@ -2806,14 +2822,14 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         a.click();
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
-        
+
         this.showNotification('Logs saved successfully', 'success');
     }
 
     toggleLogsRow() {
         const logsRow = this.elements.logsRow;
         if (!logsRow) return;
-        
+
         logsRow.classList.toggle('collapsed');
     }
 
@@ -2825,7 +2841,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             container.id = 'toast-container';
             document.body.appendChild(container);
         }
-        
+
         // Get icon based on type
         const icons = {
             success: '✓',
@@ -2833,7 +2849,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             warning: '⚠',
             info: 'ℹ'
         };
-        
+
         // Create toast element
         const toast = document.createElement('div');
         toast.className = `toast toast-${type}`;
@@ -2847,12 +2863,12 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 <div class="toast-progress-bar" style="animation-duration: ${duration}ms;"></div>
             </div>
         `;
-        
+
         container.appendChild(toast);
-        
+
         // Log to console
         console.log(`[${type.toUpperCase()}] ${message}`);
-        
+
         // Auto-remove after duration
         setTimeout(() => {
             if (toast.parentElement) {
@@ -2864,7 +2880,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 }, 300);
             }
         }, duration);
-        
+
         return toast;
     }
 
@@ -2966,39 +2982,39 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         const generationThroughputEl = document.getElementById('metric-generation-throughput');
         const kvCacheUsageEl = document.getElementById('metric-kv-cache-usage');
         const prefixCacheHitEl = document.getElementById('metric-prefix-cache-hit');
-        
+
         if (promptTokensEl) {
             promptTokensEl.textContent = metrics.promptTokens || '-';
             promptTokensEl.classList.add('updated');
             setTimeout(() => promptTokensEl.classList.remove('updated'), 500);
         }
-        
+
         if (completionTokensEl) {
             completionTokensEl.textContent = metrics.completionTokens || '-';
             completionTokensEl.classList.add('updated');
             setTimeout(() => completionTokensEl.classList.remove('updated'), 500);
         }
-        
+
         if (totalTokensEl) {
             const total = (metrics.totalTokens || (metrics.promptTokens + metrics.completionTokens));
             totalTokensEl.textContent = total;
             totalTokensEl.classList.add('updated');
             setTimeout(() => totalTokensEl.classList.remove('updated'), 500);
         }
-        
+
         if (timeTakenEl) {
             timeTakenEl.textContent = `${metrics.timeTaken.toFixed(2)}s`;
             timeTakenEl.classList.add('updated');
             setTimeout(() => timeTakenEl.classList.remove('updated'), 500);
         }
-        
+
         if (tokensPerSecEl) {
             const tokensPerSec = metrics.completionTokens / metrics.timeTaken;
             tokensPerSecEl.textContent = tokensPerSec.toFixed(2);
             tokensPerSecEl.classList.add('updated');
             setTimeout(() => tokensPerSecEl.classList.remove('updated'), 500);
         }
-        
+
         // New metrics
         if (promptThroughputEl) {
             // Calculate prompt throughput: prompt_tokens / time_to_first_token
@@ -3013,7 +3029,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             promptThroughputEl.classList.add('updated');
             setTimeout(() => promptThroughputEl.classList.remove('updated'), 500);
         }
-        
+
         if (generationThroughputEl) {
             // Calculate generation throughput: completion_tokens / (total_time - time_to_first_token)
             if (metrics.timeToFirstToken) {
@@ -3032,14 +3048,14 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             generationThroughputEl.classList.add('updated');
             setTimeout(() => generationThroughputEl.classList.remove('updated'), 500);
         }
-        
+
         if (kvCacheUsageEl) {
             // GPU KV cache usage - from vLLM stats if available
             if (metrics.kvCacheUsage !== undefined && metrics.kvCacheUsage !== null) {
                 // Server already sends percentage values (e.g., 0.2 = 0.2%, not 20%)
                 // No conversion needed
                 const percentage = metrics.kvCacheUsage.toFixed(1);
-                
+
                 // Add staleness indicator if metrics are old
                 if (metrics.metricsAge !== undefined && metrics.metricsAge > 5) {
                     kvCacheUsageEl.textContent = `${percentage}% ⚠️`;
@@ -3058,14 +3074,14 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             kvCacheUsageEl.classList.add('updated');
             setTimeout(() => kvCacheUsageEl.classList.remove('updated'), 500);
         }
-        
+
         if (prefixCacheHitEl) {
             // Prefix cache hit rate - from vLLM stats if available
             if (metrics.prefixCacheHitRate !== undefined && metrics.prefixCacheHitRate !== null) {
                 // Server already sends percentage values (e.g., 36.1 = 36.1%, not 3610%)
                 // No conversion needed
                 const percentage = metrics.prefixCacheHitRate.toFixed(1);
-                
+
                 // Add staleness indicator if metrics are old
                 if (metrics.metricsAge !== undefined && metrics.metricsAge > 5) {
                     prefixCacheHitEl.textContent = `${percentage}% ⚠️`;
@@ -3089,17 +3105,17 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
     updateToolParserVisibility() {
         // Show/hide the tool parser dropdown based on enable tool calling checkbox
         if (this.elements.toolParserGroup) {
-            this.elements.toolParserGroup.style.display = 
+            this.elements.toolParserGroup.style.display =
                 this.elements.enableToolCalling.checked ? 'block' : 'none';
         }
         // Also update the tool panel status
         this.updateToolPanelStatus();
     }
-    
+
     updateToolPanelStatus() {
         // Update the Tool Calling panel to reflect server configuration
         const toolCallingEnabled = this.elements.enableToolCalling?.checked ?? true;
-        
+
         // Get the effective parser (auto-detect if not set)
         let parser = this.elements.toolCallParser?.value || '';
         if (!parser && toolCallingEnabled) {
@@ -3120,7 +3136,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 parser = 'hermes';
             }
         }
-        
+
         // Update warning/status banners
         if (this.elements.toolServerWarning) {
             this.elements.toolServerWarning.style.display = toolCallingEnabled ? 'none' : 'flex';
@@ -3135,14 +3151,14 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 this.elements.toolServerStatus.style.display = 'none';
             }
         }
-        
+
         // Disable/enable tool controls based on server support
         const controlElements = [
             this.elements.toolChoiceRow,
             this.elements.toolPresetsRow,
             this.elements.toolsListContainer
         ];
-        
+
         controlElements.forEach(el => {
             if (el) {
                 if (toolCallingEnabled) {
@@ -3152,7 +3168,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 }
             }
         });
-        
+
         // Update tool choice dropdown - if server doesn't support, set to None
         if (!toolCallingEnabled && this.elements.toolChoice) {
             this.elements.toolChoice.value = '';
@@ -3169,15 +3185,15 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         const enablePrefixCaching = this.elements.enablePrefixCaching.checked;
         const isCpuMode = this.elements.modeCpu.checked;
         const hfToken = this.elements.hfToken.value.trim();
-        
+
         // Build command string
         let cmd;
-        
+
         if (isCpuMode) {
             // CPU mode: show environment variables and use openai.api_server
             const cpuKvcache = this.elements.cpuKvcache?.value || '4';
             const cpuThreads = this.elements.cpuThreads?.value || 'auto';
-            
+
             cmd = `# CPU Mode - Set environment variables:\n`;
             cmd += `export VLLM_CPU_KVCACHE_SPACE=${cpuKvcache}\n`;
             cmd += `export VLLM_CPU_OMP_THREADS_BIND=${cpuThreads}\n`;
@@ -3198,12 +3214,12 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         } else {
             // GPU mode: use openai.api_server
             const gpuDevice = this.elements.gpuDevice.value.trim();
-            
+
             if (gpuDevice) {
                 cmd = `# GPU Device Selection:\n`;
                 cmd += `export CUDA_VISIBLE_DEVICES=${gpuDevice}\n\n`;
             }
-            
+
             if (hfToken) {
                 cmd += `# Set HF token for gated models:\n`;
                 cmd += `export HF_TOKEN=[YOUR_TOKEN]\n\n`;
@@ -3213,11 +3229,11 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             cmd += ` \\\n  --host ${host}`;
             cmd += ` \\\n  --port ${port}`;
             cmd += ` \\\n  --dtype ${dtype}`;
-            
+
             // GPU-specific flags
             const tensorParallel = this.elements.tensorParallel.value;
             const gpuMemory = parseFloat(this.elements.gpuMemory.value) / 100;
-            
+
             cmd += ` \\\n  --tensor-parallel-size ${tensorParallel}`;
             cmd += ` \\\n  --gpu-memory-utilization ${gpuMemory}`;
             cmd += ` \\\n  --load-format auto`;
@@ -3226,24 +3242,24 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 cmd += ` \\\n  --max-num-batched-tokens 8192`;
             }
         }
-        
+
         if (maxModelLen) {
             cmd += ` \\\n  --max-model-len ${maxModelLen}`;
             cmd += ` \\\n  --max-num-batched-tokens ${maxModelLen}`;
         }
-        
+
         if (trustRemoteCode) {
             cmd += ` \\\n  --trust-remote-code`;
         }
-        
+
         if (enablePrefixCaching) {
             cmd += ` \\\n  --enable-prefix-caching`;
         }
-        
+
         // Tool calling flags
         const enableToolCalling = this.elements.enableToolCalling.checked;
         const toolCallParser = this.elements.toolCallParser.value;
-        
+
         if (enableToolCalling) {
             // Determine parser (auto-detect based on model name if not explicitly set)
             let parser = toolCallParser;
@@ -3262,36 +3278,36 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     parser = 'granite-20b-fc';
                 }
             }
-            
+
             if (parser) {
                 cmd += ` \\\n  --enable-auto-tool-choice`;
                 cmd += ` \\\n  --tool-call-parser ${parser}`;
             }
         }
-        
+
         // Add chat template flag (vLLM requires this for /v1/chat/completions)
         cmd += ` \\\n  --chat-template <auto-detected-or-custom>`;
-        
+
         // Update the display (use value for textarea)
         this.elements.commandText.value = cmd;
     }
 
     async copyCommand() {
         const commandText = this.elements.commandText.value;
-        
+
         try {
             await navigator.clipboard.writeText(commandText);
-            
+
             // Visual feedback
             const originalText = this.elements.copyCommandBtn.textContent;
             this.elements.copyCommandBtn.textContent = 'Copied!';
             this.elements.copyCommandBtn.classList.add('copied');
-            
+
             setTimeout(() => {
                 this.elements.copyCommandBtn.textContent = originalText;
                 this.elements.copyCommandBtn.classList.remove('copied');
             }, 2000);
-            
+
             this.showNotification('Command copied to clipboard!', 'success');
         } catch (err) {
             console.error('Failed to copy command:', err);
@@ -3307,7 +3323,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
     toggleTemplateSettings() {
         const content = this.elements.templateSettingsContent;
         const icon = this.elements.templateSettingsToggle.querySelector('.toggle-icon');
-        
+
         if (content.style.display === 'none') {
             content.style.display = 'block';
             icon.classList.add('open');
@@ -3320,57 +3336,57 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             icon.classList.remove('open');
         }
     }
-    
+
     async fetchChatTemplate() {
         try {
             const response = await fetch('/api/chat/template');
             if (response.ok) {
                 const data = await response.json();
                 console.log('Fetched chat template from backend:', data);
-                
+
                 // Update the template fields with the model's actual template
                 this.elements.chatTemplate.value = data.template;
                 this.elements.stopTokens.value = data.stop_tokens.join(', ');
-                
+
                 // Show a notification about where the template came from
                 if (data.note) {
                     this.addLog(`[INFO] ${data.note}`, 'info');
                 }
-                
+
                 this.addLog(`[INFO] Chat template loaded from ${data.source} for model: ${data.model}`, 'info');
             }
         } catch (error) {
             console.error('Failed to fetch chat template:', error);
         }
     }
-    
+
     updateTemplateForModel(silent = false) {
         const model = this.elements.customModel.value.trim() || this.elements.modelSelect.value;
         const template = this.getTemplateForModel(model);
         const stopTokens = this.getStopTokensForModel(model);
-        
+
         // Update the template and stop tokens fields
         this.elements.chatTemplate.value = template;
         this.elements.stopTokens.value = stopTokens.join(', ');
-        
+
         console.log(`Template updated for model: ${model}`);
-        
+
         // Only show feedback if not silent (i.e., when user actively changes model)
         if (!silent) {
             // Show visual feedback that template was updated
             this.showNotification(`Chat template reference updated for: ${model.split('/').pop()}`, 'success');
-            
+
             // Add visual highlight to template fields briefly
             this.elements.chatTemplate.style.transition = 'background-color 0.3s ease';
             this.elements.stopTokens.style.transition = 'background-color 0.3s ease';
             this.elements.chatTemplate.style.backgroundColor = '#10b98120';
             this.elements.stopTokens.style.backgroundColor = '#10b98120';
-            
+
             setTimeout(() => {
                 this.elements.chatTemplate.style.backgroundColor = '';
                 this.elements.stopTokens.style.backgroundColor = '';
             }, 1000);
-            
+
             // Note: vLLM handles templates automatically
             if (this.serverRunning) {
                 this.showNotification('✅ Note: vLLM applies templates automatically from tokenizer config', 'success');
@@ -3378,10 +3394,10 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             }
         }
     }
-    
+
     getTemplateForModel(modelName) {
         const model = modelName.toLowerCase();
-        
+
         // Llama 3/3.1/3.2 models (use new format with special tokens)
         // Reference: Meta's official Llama 3 tokenizer_config.json
         if (model.includes('llama-3') && (model.includes('llama-3.1') || model.includes('llama-3.2') || model.includes('llama-3-'))) {
@@ -3401,7 +3417,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 + "{% endif %}"
             );
         }
-        
+
         // Llama 2 models (older [INST] format with <<SYS>>)
         // Reference: Meta's official Llama 2 tokenizer_config.json
         else if (model.includes('llama-2') || model.includes('llama2')) {
@@ -3424,7 +3440,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 + "{% endfor %}"
             );
         }
-        
+
         // Mistral/Mixtral models (similar to Llama 2 but simpler)
         // Reference: Mistral AI's official tokenizer_config.json
         else if (model.includes('mistral') || model.includes('mixtral')) {
@@ -3444,7 +3460,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 + "{% endfor %}"
             );
         }
-        
+
         // Gemma models (Google)
         // Reference: Google's official Gemma tokenizer_config.json
         else if (model.includes('gemma')) {
@@ -3468,7 +3484,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 + "{% endif %}"
             );
         }
-        
+
         // TinyLlama (use ChatML format)
         // Reference: TinyLlama's official tokenizer_config.json
         else if (model.includes('tinyllama') || model.includes('tiny-llama')) {
@@ -3487,7 +3503,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 + "{% endfor %}"
             );
         }
-        
+
         // CodeLlama (uses Llama 2 format)
         // Reference: Meta's CodeLlama tokenizer_config.json
         else if (model.includes('codellama') || model.includes('code-llama')) {
@@ -3510,7 +3526,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 + "{% endfor %}"
             );
         }
-        
+
         // Default generic template for unknown models
         else {
             console.log('Using generic chat template for model:', modelName);
@@ -3530,46 +3546,46 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             );
         }
     }
-    
+
     getStopTokensForModel(modelName) {
         const model = modelName.toLowerCase();
-        
+
         // Llama 3/3.1/3.2 models - use special tokens
         if (model.includes('llama-3') && (model.includes('llama-3.1') || model.includes('llama-3.2') || model.includes('llama-3-'))) {
             return ["<|eot_id|>", "<|end_of_text|>"];
         }
-        
+
         // Llama 2 models - use special tokens
         else if (model.includes('llama-2') || model.includes('llama2')) {
             return ["</s>", "[INST]"];
         }
-        
+
         // Mistral/Mixtral models - use special tokens
         else if (model.includes('mistral') || model.includes('mixtral')) {
             return ["</s>", "[INST]"];
         }
-        
+
         // Gemma models - use special tokens
         else if (model.includes('gemma')) {
             return ["<end_of_turn>", "<start_of_turn>"];
         }
-        
+
         // TinyLlama - use ChatML special tokens
         else if (model.includes('tinyllama') || model.includes('tiny-llama')) {
             return ["</s>", "<|user|>", "<|system|>", "<|assistant|>"];
         }
-        
+
         // CodeLlama - use Llama 2 tokens
         else if (model.includes('codellama') || model.includes('code-llama')) {
             return ["</s>", "[INST]"];
         }
-        
+
         // Default generic stop tokens for unknown models
         else {
             return ["\\n\\nUser:", "\\n\\nAssistant:"];
         }
     }
-    
+
     optimizeSettingsForModel() {
         // This function can be used to optimize settings based on model
         // Currently disabled to use user-configured defaults
@@ -3579,11 +3595,11 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
     // ============ Resize Functionality ============
     initResize() {
         const resizeHandles = document.querySelectorAll('.resize-handle');
-        
+
         resizeHandles.forEach(handle => {
             handle.addEventListener('mousedown', (e) => this.startResize(e, handle));
         });
-        
+
         document.addEventListener('mousemove', (e) => this.resize(e));
         document.addEventListener('mouseup', () => this.stopResize());
     }
@@ -3593,21 +3609,21 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         this.isResizing = true;
         this.currentResizer = handle;
         this.resizeDirection = handle.dataset.direction;
-        
+
         // Add resizing class to body
         document.body.classList.add(
             this.resizeDirection === 'horizontal' ? 'resizing' : 'resizing-vertical'
         );
-        
+
         // Store initial positions
         this.startX = e.clientX;
         this.startY = e.clientY;
-        
+
         // Get the panel being resized
         if (this.resizeDirection === 'horizontal') {
             // Find which resizable section this handle belongs to
             const parentResizable = handle.closest('.resizable');
-            
+
             // Determine which panel to resize based on the parent's ID
             if (parentResizable.id === 'config-panel') {
                 // Left handle: resize config panel (normal direction)
@@ -3618,7 +3634,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 this.resizingPanel = document.getElementById('logs-panel');
                 this.resizeMode = 'right';
             }
-            
+
             this.startWidth = this.resizingPanel.offsetWidth;
         } else {
             // Vertical resize (horizontal handles for row resizing)
@@ -3627,7 +3643,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 // Handle between main content and performance metrics sections
                 this.resizingPanel = document.getElementById('metrics-panel');
                 this.startHeight = this.resizingPanel.offsetHeight;
-                
+
                 // Also store the main content height for inverse resizing
                 const mainContent = document.querySelector('.main-content');
                 this.mainContentStartHeight = mainContent.offsetHeight;
@@ -3636,7 +3652,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 this.resizingPanel = document.getElementById('chat-metrics-panel');
                 this.resizeMode = 'chat-metrics';
                 this.startHeight = this.resizingPanel.offsetHeight;
-                
+
                 // Also store the chat panel reference for inverse resizing
                 this.chatPanel = handle.closest('.chat-section').querySelector('.panel');
                 this.chatPanelStartHeight = this.chatPanel.offsetHeight;
@@ -3646,67 +3662,67 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
 
     resize(e) {
         if (!this.isResizing) return;
-        
+
         e.preventDefault();
-        
+
         if (this.resizeDirection === 'horizontal') {
             // Horizontal resize (columns)
             const deltaX = e.clientX - this.startX;
             let newWidth;
-            
+
             // For the right panel (logs), we resize in reverse direction
             if (this.resizeMode === 'right') {
                 newWidth = this.startWidth - deltaX; // Dragging left makes logs bigger
             } else {
                 newWidth = this.startWidth + deltaX; // Dragging right makes config bigger
             }
-            
+
             // Apply minimum width
             if (newWidth >= 200) {
                 this.resizingPanel.style.width = `${newWidth}px`;
                 this.resizingPanel.style.flexShrink = '0';
-                
+
                 // Ensure the chat section remains flexible
                 const chatSection = document.querySelector('.chat-section');
                 chatSection.style.flex = '1';
                 chatSection.style.width = 'auto';
                 chatSection.style.minWidth = '200px';
-                
+
                 // Force layout recalculation for better responsiveness
                 this.resizingPanel.offsetWidth;
             }
         } else {
             // Vertical resize (horizontal handles for row resizing)
             const deltaY = e.clientY - this.startY;
-            
+
             if (this.resizeMode === 'chat-metrics') {
                 // Special handling for chat-metrics resize
                 // Dragging up makes metrics bigger (opposite direction)
                 const newMetricsHeight = this.startHeight - deltaY;
                 const newChatHeight = this.chatPanelStartHeight + deltaY;
-                
+
                 // Apply minimum heights
                 if (newMetricsHeight >= 100 && newChatHeight >= 300) {
                     this.resizingPanel.style.height = `${newMetricsHeight}px`;
                     this.chatPanel.style.maxHeight = `${newChatHeight}px`;
                     this.chatPanel.style.minHeight = `${newChatHeight}px`;
-                    
+
                     // Force layout recalculation
                     this.resizingPanel.offsetHeight;
                 }
             } else {
                 const newHeight = this.startHeight + deltaY; // Dragging down makes panel bigger
-                
+
                 // Apply minimum height
                 if (newHeight >= 200) {
                     // Set height on both the outer section and inner panel
                     this.resizingPanel.style.height = `${newHeight}px`;
-                    
+
                     const innerPanel = this.resizingPanel.querySelector('.panel');
                     if (innerPanel) {
                         innerPanel.style.height = `${newHeight}px`;
                     }
-                    
+
                     // Also adjust the main-content height inversely
                     // When metrics gets bigger, main content should shrink
                     if (this.mainContentStartHeight) {
@@ -3717,7 +3733,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                             mainContent.style.maxHeight = `${newMainHeight}px`;
                         }
                     }
-                    
+
                     // Force layout recalculation
                     this.resizingPanel.offsetHeight;
                 }
@@ -3727,13 +3743,13 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
 
     stopResize() {
         if (!this.isResizing) return;
-        
+
         this.isResizing = false;
         this.currentResizer = null;
-        
+
         // Remove resizing class
         document.body.classList.remove('resizing', 'resizing-vertical');
-        
+
         // Save layout preferences to localStorage
         this.saveLayoutPreferences();
     }
@@ -3744,7 +3760,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             logsWidth: document.getElementById('logs-panel')?.offsetWidth,
             metricsHeight: document.querySelector('.metrics-section .panel')?.offsetHeight
         };
-        
+
         try {
             localStorage.setItem('vllm-webui-layout', JSON.stringify(layout));
         } catch (e) {
@@ -3757,18 +3773,18 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             const saved = localStorage.getItem('vllm-webui-layout');
             if (saved) {
                 const layout = JSON.parse(saved);
-                
+
                 if (layout.configWidth) {
                     const configPanel = document.getElementById('config-panel');
                     if (configPanel) configPanel.style.width = `${layout.configWidth}px`;
                 }
-                
+
                 if (layout.logsWidth) {
                     const logsPanel = document.getElementById('logs-panel');
                     if (logsPanel) logsPanel.style.width = `${layout.logsWidth}px`;
                 }
-                
-                
+
+
                 if (layout.metricsHeight) {
                     const metricsPanel = document.querySelector('.metrics-section .panel');
                     if (metricsPanel) metricsPanel.style.height = `${layout.metricsHeight}px`;
@@ -3778,20 +3794,20 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             console.warn('Could not load layout preferences:', e);
         }
     }
-    
+
     // NOTE: Benchmark command preview and copy methods are injected by GuideLLM module
-    
+
     // ===============================================
     // COMMUNITY RECIPES
     // ===============================================
-    
+
     recipesData = null;
     currentRecipeFilter = 'all';
-    
+
     async openRecipesModal() {
         if (this.elements.recipesModal) {
             this.elements.recipesModal.style.display = 'flex';
-            
+
             // Load recipes if not already loaded
             if (!this.recipesData) {
                 await this.loadRecipes();
@@ -3799,13 +3815,13 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             this.renderRecipes();
         }
     }
-    
+
     closeRecipesModal() {
         if (this.elements.recipesModal) {
             this.elements.recipesModal.style.display = 'none';
         }
     }
-    
+
     async loadRecipes() {
         try {
             const response = await fetch('/api/recipes');
@@ -3820,13 +3836,13 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             this.recipesData = { categories: [] };
         }
     }
-    
+
     renderRecipes() {
         if (!this.elements.recipesCategories || !this.recipesData) return;
-        
+
         const searchTerm = this.elements.recipesSearchInput?.value?.toLowerCase() || '';
         const categories = this.recipesData.categories || [];
-        
+
         if (categories.length === 0) {
             this.elements.recipesCategories.innerHTML = `
                 <div class="no-recipes-found">
@@ -3836,29 +3852,29 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             `;
             return;
         }
-        
+
         let html = '';
-        
+
         for (const category of categories) {
             // Filter recipes based on search and tag
             const filteredRecipes = category.recipes.filter(recipe => {
                 // Search matches recipe fields OR category name/id
-                const matchesSearch = !searchTerm || 
+                const matchesSearch = !searchTerm ||
                     recipe.name.toLowerCase().includes(searchTerm) ||
                     recipe.model_id.toLowerCase().includes(searchTerm) ||
                     recipe.description.toLowerCase().includes(searchTerm) ||
                     category.name.toLowerCase().includes(searchTerm) ||
                     category.id.toLowerCase().includes(searchTerm);
-                
-                const matchesTag = this.currentRecipeFilter === 'all' || 
+
+                const matchesTag = this.currentRecipeFilter === 'all' ||
                     (recipe.tags && recipe.tags.includes(this.currentRecipeFilter));
-                
+
                 return matchesSearch && matchesTag;
             });
-            
+
             // Skip empty categories
             if (filteredRecipes.length === 0) continue;
-            
+
             html += `
                 <div class="recipe-category" data-category="${category.id}">
                     <div class="category-header" onclick="window.vllmUI.toggleCategoryExpand('${category.id}')">
@@ -3879,22 +3895,22 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 </div>
             `;
         }
-        
+
         if (!html) {
             html = `<div class="no-recipes-found">No recipes match your search.</div>`;
         }
-        
+
         this.elements.recipesCategories.innerHTML = html;
     }
-    
+
     renderRecipeCard(recipe, category) {
-        const tags = (recipe.tags || []).map(tag => 
+        const tags = (recipe.tags || []).map(tag =>
             `<span class="recipe-tag ${tag}">${tag}</span>`
         ).join('');
-        
-        const requiresToken = recipe.requires_hf_token ? 
+
+        const requiresToken = recipe.requires_hf_token ?
             '<span class="recipe-tag" style="background: rgba(245, 158, 11, 0.2); color: #f59e0b;">requires HF token</span>' : '';
-        
+
         // Build config display
         const config = recipe.config || {};
         const configItems = [];
@@ -3906,7 +3922,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         if (config.gpu_memory_utilization) configItems.push(`<span class="config-item"><span class="config-label">GPU Mem:</span> ${Math.round(config.gpu_memory_utilization * 100)}%</span>`);
         if (config.trust_remote_code) configItems.push(`<span class="config-item config-flag">trust-remote-code</span>`);
         if (config.enable_expert_parallel) configItems.push(`<span class="config-item config-flag">expert-parallel</span>`);
-        
+
         const configHtml = configItems.length > 0 ? `
             <div class="recipe-config">
                 <div class="config-header">
@@ -3918,7 +3934,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 </div>
             </div>
         ` : '';
-        
+
         return `
             <div class="recipe-card" data-recipe-id="${recipe.id}" data-category-id="${category.id}">
                 <div class="recipe-header">
@@ -3954,51 +3970,51 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             </div>
         `;
     }
-    
+
     toggleCategoryExpand(categoryId) {
         const recipesDiv = document.getElementById(`recipes-${categoryId}`);
         const expandIcon = document.getElementById(`expand-${categoryId}`);
-        
+
         if (recipesDiv && expandIcon) {
             recipesDiv.classList.toggle('expanded');
             expandIcon.classList.toggle('expanded');
         }
     }
-    
+
     filterRecipes() {
         this.renderRecipes();
     }
-    
+
     filterRecipesByTag(tag) {
         this.currentRecipeFilter = tag;
-        
+
         // Update active state on buttons
         const buttons = this.elements.recipesFilterTags?.querySelectorAll('.tag-btn');
         buttons?.forEach(btn => {
             btn.classList.toggle('active', btn.dataset.tag === tag);
         });
-        
+
         this.renderRecipes();
     }
-    
+
     async loadRecipeConfig(categoryId, recipeId) {
         try {
             const response = await fetch(`/api/recipes/${categoryId}/${recipeId}`);
             if (!response.ok) {
                 throw new Error('Failed to load recipe');
             }
-            
+
             const data = await response.json();
             const recipe = data.recipe;
             const config = recipe.config || {};
-            
+
             // Set model
             if (recipe.model_id) {
                 this.elements.customModel.value = recipe.model_id;
                 // Clear the select dropdown
                 this.elements.modelSelect.value = '';
             }
-            
+
             // Set CPU/GPU mode
             if (config.use_cpu) {
                 this.elements.modeCpu.checked = true;
@@ -4007,89 +4023,89 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 this.elements.modeGpu.checked = true;
                 this.toggleComputeMode();
             }
-            
+
             // Set tensor parallel size
             if (config.tensor_parallel_size && this.elements.tensorParallel) {
                 this.elements.tensorParallel.value = config.tensor_parallel_size;
             }
-            
+
             // Set GPU memory utilization
             if (config.gpu_memory_utilization && this.elements.gpuMemory) {
                 this.elements.gpuMemory.value = config.gpu_memory_utilization;
             }
-            
+
             // Set max model length
             if (config.max_model_len && this.elements.maxModelLen) {
                 this.elements.maxModelLen.value = config.max_model_len;
             }
-            
+
             // Set dtype
             if (config.dtype && this.elements.dtype) {
                 this.elements.dtype.value = config.dtype;
             }
-            
+
             // Set trust remote code
             if (config.trust_remote_code !== undefined && this.elements.trustRemoteCode) {
                 this.elements.trustRemoteCode.checked = config.trust_remote_code;
             }
-            
+
             // Set CPU-specific settings
             if (config.cpu_kvcache_space && this.elements.cpuKvcache) {
                 this.elements.cpuKvcache.value = config.cpu_kvcache_space;
             }
-            
+
             // Update command preview
             this.updateCommandPreview();
-            
+
             // Close modal
             this.closeRecipesModal();
-            
+
             // Show success toast
             this.showRecipeToast(`✅ Loaded: ${recipe.name}`);
-            
+
             // Highlight if HF token is required
             if (recipe.requires_hf_token && this.elements.hfToken) {
                 this.elements.hfToken.focus();
                 this.showNotification('This model requires a HuggingFace token', 'warning');
             }
-            
+
         } catch (error) {
             console.error('Error loading recipe config:', error);
             this.showNotification('Failed to load recipe configuration', 'error');
         }
     }
-    
+
     showRecipeToast(message) {
         // Remove existing toast
         const existingToast = document.querySelector('.recipe-toast');
         if (existingToast) {
             existingToast.remove();
         }
-        
+
         const toast = document.createElement('div');
         toast.className = 'recipe-toast';
         toast.textContent = message;
         document.body.appendChild(toast);
-        
+
         // Auto-remove after 3 seconds
         setTimeout(() => {
             toast.classList.add('hide');
             setTimeout(() => toast.remove(), 300);
         }, 3000);
     }
-    
+
     async syncRecipesFromGitHub() {
         const syncBtn = this.elements.syncRecipesBtn;
         if (!syncBtn) return;
-        
+
         // Get GitHub token if provided
         const githubToken = this.elements.githubTokenInput?.value?.trim() || '';
-        
+
         // Show loading state
         const originalText = syncBtn.innerHTML;
         syncBtn.innerHTML = '⏳ Syncing';
         syncBtn.disabled = true;
-        
+
         // Show loading in categories area
         if (this.elements.recipesCategories) {
             this.elements.recipesCategories.innerHTML = `
@@ -4102,7 +4118,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 </div>
             `;
         }
-        
+
         try {
             const response = await fetch('/api/recipes/sync', {
                 method: 'POST',
@@ -4113,23 +4129,23 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     github_token: githubToken || null
                 })
             });
-            
+
             const data = await response.json();
-            
+
             if (data.success) {
                 // Clear cached data to force reload
                 this.recipesData = null;
-                
+
                 // Reload recipes
                 await this.loadRecipes();
                 this.renderRecipes();
-                
+
                 // Show success message
                 const catalogInfo = data.catalog || {};
                 this.showRecipeToast(
                     `✅ Synced! ${catalogInfo.categories || 0} categories, ${catalogInfo.total_recipes || 0} recipes`
                 );
-                
+
                 console.log('Recipes sync result:', data);
             } else {
                 // Show error
@@ -4137,7 +4153,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     `Sync failed: ${data.message || data.error || 'Unknown error'}`,
                     'error'
                 );
-                
+
                 // Restore previous recipes display
                 if (this.recipesData) {
                     this.renderRecipes();
@@ -4155,7 +4171,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         } catch (error) {
             console.error('Error syncing recipes:', error);
             this.showNotification('Failed to sync recipes from GitHub', 'error');
-            
+
             // Restore previous recipes display
             if (this.recipesData) {
                 this.renderRecipes();
@@ -4175,52 +4191,52 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             syncBtn.disabled = false;
         }
     }
-    
+
     // ===============================================
     // RECIPE EDIT/ADD FUNCTIONALITY
     // ===============================================
-    
+
     editingRecipe = null;
     editingCategory = null;
-    
+
     openEditRecipeModal(categoryId, recipeId) {
         // Find the recipe in the data
         const category = this.recipesData?.categories?.find(c => c.id === categoryId);
         const recipe = category?.recipes?.find(r => r.id === recipeId);
-        
+
         if (!recipe) {
             this.showNotification('Recipe not found', 'error');
             return;
         }
-        
+
         this.editingRecipe = recipe;
         this.editingCategory = category;
-        
+
         // Show the edit modal
         const modal = document.getElementById('edit-recipe-modal');
         if (!modal) {
             this.createEditRecipeModal();
         }
-        
+
         this.populateEditForm(recipe, category);
         document.getElementById('edit-recipe-modal').style.display = 'flex';
     }
-    
+
     openAddRecipeModal() {
         this.editingRecipe = null;
         this.editingCategory = null;
-        
+
         // Show the edit modal in "add" mode
         const modal = document.getElementById('edit-recipe-modal');
         if (!modal) {
             this.createEditRecipeModal();
         }
-        
+
         // Clear form and set to add mode
         this.populateEditForm(null, null);
         document.getElementById('edit-recipe-modal').style.display = 'flex';
     }
-    
+
     closeEditRecipeModal() {
         const modal = document.getElementById('edit-recipe-modal');
         if (modal) {
@@ -4229,7 +4245,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         this.editingRecipe = null;
         this.editingCategory = null;
     }
-    
+
     createEditRecipeModal() {
         const modalHtml = `
             <div id="edit-recipe-modal" class="modal" style="display: none;">
@@ -4359,22 +4375,22 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 </div>
             </div>
         `;
-        
+
         document.body.insertAdjacentHTML('beforeend', modalHtml);
     }
-    
+
     populateEditForm(recipe, category) {
         const isEdit = !!recipe;
-        
+
         // Update title
         document.getElementById('edit-recipe-title').textContent = isEdit ? '✏️ Edit Recipe' : '➕ Add New Recipe';
-        
+
         // Show/hide delete button
         const deleteBtn = document.getElementById('delete-recipe-btn');
         if (deleteBtn) {
             deleteBtn.style.display = isEdit ? 'inline-block' : 'none';
         }
-        
+
         // Populate category dropdown
         const categorySelect = document.getElementById('edit-recipe-category');
         categorySelect.innerHTML = '<option value="">Select category...</option>';
@@ -4394,12 +4410,12 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             newOption.textContent = '➕ Create New Category...';
             categorySelect.appendChild(newOption);
         }
-        
+
         // Populate form fields
         document.getElementById('edit-recipe-name').value = recipe?.name || '';
         document.getElementById('edit-recipe-model-id').value = recipe?.model_id || '';
         document.getElementById('edit-recipe-description').value = recipe?.description || '';
-        
+
         // Config
         const config = recipe?.config || {};
         document.getElementById('edit-recipe-tp').value = config.tensor_parallel_size || 1;
@@ -4411,42 +4427,42 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         document.getElementById('edit-recipe-trust-remote').checked = config.trust_remote_code || false;
         document.getElementById('edit-recipe-expert-parallel').checked = config.enable_expert_parallel || false;
         document.getElementById('edit-recipe-hf-token').checked = recipe?.requires_hf_token || false;
-        
+
         // Hardware
         document.getElementById('edit-recipe-hw-rec').value = recipe?.hardware?.recommended || '';
         document.getElementById('edit-recipe-hw-min').value = recipe?.hardware?.minimum || '';
-        
+
         // Tags
         document.getElementById('edit-recipe-tags').value = (recipe?.tags || []).join(', ');
         document.getElementById('edit-recipe-docs-url').value = recipe?.docs_url || '';
     }
-    
+
     async saveRecipe(event) {
         event.preventDefault();
-        
+
         // Gather form data
         let categoryId = document.getElementById('edit-recipe-category').value;
-        
+
         // Handle new category creation
         if (categoryId === '__new__') {
             const newCatName = prompt('Enter new category name:');
             if (!newCatName) return;
             categoryId = newCatName.toLowerCase().replace(/[^a-z0-9]/g, '');
         }
-        
+
         if (!categoryId) {
             this.showNotification('Please select a category', 'error');
             return;
         }
-        
+
         const name = document.getElementById('edit-recipe-name').value.trim();
         const modelId = document.getElementById('edit-recipe-model-id').value.trim();
-        
+
         if (!name || !modelId) {
             this.showNotification('Name and Model ID are required', 'error');
             return;
         }
-        
+
         // Build recipe object
         const recipeData = {
             id: this.editingRecipe?.id || name.toLowerCase().replace(/[^a-z0-9]/g, '-'),
@@ -4465,40 +4481,40 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 .map(t => t.trim().toLowerCase())
                 .filter(t => t)
         };
-        
+
         // Add config values only if set
         const tp = parseInt(document.getElementById('edit-recipe-tp').value);
         if (tp && tp > 1) recipeData.config.tensor_parallel_size = tp;
-        
+
         const pp = parseInt(document.getElementById('edit-recipe-pp').value);
         if (pp && pp > 1) recipeData.config.pipeline_parallel_size = pp;
-        
+
         const dp = parseInt(document.getElementById('edit-recipe-dp').value);
         if (dp && dp > 1) recipeData.config.data_parallel_size = dp;
-        
+
         const maxLen = parseInt(document.getElementById('edit-recipe-max-len').value);
         if (maxLen) recipeData.config.max_model_len = maxLen;
-        
+
         const dtype = document.getElementById('edit-recipe-dtype').value;
         if (dtype) recipeData.config.dtype = dtype;
-        
+
         const gpuMem = parseInt(document.getElementById('edit-recipe-gpu-mem').value);
         if (gpuMem) recipeData.config.gpu_memory_utilization = gpuMem / 100;
-        
+
         if (document.getElementById('edit-recipe-trust-remote').checked) {
             recipeData.config.trust_remote_code = true;
         }
-        
+
         if (document.getElementById('edit-recipe-expert-parallel').checked) {
             recipeData.config.enable_expert_parallel = true;
         }
-        
+
         // Determine if creating new category
         const existingCategory = this.recipesData?.categories?.find(c => c.id === categoryId);
-        const newCategoryName = document.getElementById('edit-recipe-category').value === '__new__' 
-            ? prompt('Enter new category name:') 
+        const newCategoryName = document.getElementById('edit-recipe-category').value === '__new__'
+            ? prompt('Enter new category name:')
             : null;
-        
+
         try {
             const response = await fetch('/api/recipes/save', {
                 method: 'POST',
@@ -4512,15 +4528,15 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     new_category_name: newCategoryName
                 })
             });
-            
+
             const data = await response.json();
-            
+
             if (data.success) {
                 // Reload recipes
                 this.recipesData = null;
                 await this.loadRecipes();
                 this.renderRecipes();
-                
+
                 this.closeEditRecipeModal();
                 this.showRecipeToast(`✅ Recipe ${this.editingRecipe ? 'updated' : 'added'}: ${name}`);
             } else {
@@ -4531,12 +4547,12 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             this.showNotification('Failed to save recipe', 'error');
         }
     }
-    
+
     async deleteRecipe() {
         if (!this.editingRecipe || !this.editingCategory) {
             return;
         }
-        
+
         const confirmed = await this.showConfirm({
             title: 'Delete Recipe',
             message: `Are you sure you want to delete "${this.editingRecipe.name}"? This action cannot be undone.`,
@@ -4546,7 +4562,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             type: 'danger'
         });
         if (!confirmed) return;
-        
+
         try {
             const response = await fetch('/api/recipes/delete', {
                 method: 'POST',
@@ -4556,15 +4572,15 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     recipe_id: this.editingRecipe.id
                 })
             });
-            
+
             const data = await response.json();
-            
+
             if (data.success) {
                 // Reload recipes
                 this.recipesData = null;
                 await this.loadRecipes();
                 this.renderRecipes();
-                
+
                 this.closeEditRecipeModal();
                 this.showRecipeToast(`🗑️ Deleted: ${this.editingRecipe.name}`);
             } else {
@@ -4575,21 +4591,21 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             this.showNotification('Failed to delete recipe', 'error');
         }
     }
-    
+
     // ==========================================
     // Tool Calling / Function Calling Methods
     // ==========================================
-    
+
     openToolEditor(toolIndex = -1) {
         this.editingToolIndex = toolIndex;
-        
+
         if (toolIndex >= 0 && toolIndex < this.tools.length) {
             // Editing existing tool
             const tool = this.tools[toolIndex];
             this.elements.toolEditorTitle.textContent = 'Edit Tool';
             this.elements.toolName.value = tool.function.name;
             this.elements.toolDescription.value = tool.function.description || '';
-            
+
             // Convert JSON Schema parameters to form-based params
             this.currentParams = this.jsonSchemaToParams(tool.function.parameters);
         } else {
@@ -4599,18 +4615,18 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             this.elements.toolDescription.value = '';
             this.currentParams = [];
         }
-        
+
         this.renderParamsList();
         this.elements.toolEditorModal.style.display = 'flex';
     }
-    
+
     // Convert JSON Schema to form-based parameters array
     jsonSchemaToParams(schema) {
         if (!schema || !schema.properties) return [];
-        
+
         const params = [];
         const required = schema.required || [];
-        
+
         for (const [name, prop] of Object.entries(schema.properties)) {
             params.push({
                 name: name,
@@ -4620,38 +4636,38 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 enum: prop.enum ? prop.enum.join(', ') : ''
             });
         }
-        
+
         return params;
     }
-    
+
     // Convert form-based parameters array to JSON Schema
     paramsToJsonSchema() {
         if (this.currentParams.length === 0) {
             return { type: 'object', properties: {} };
         }
-        
+
         const properties = {};
         const required = [];
-        
+
         for (const param of this.currentParams) {
             if (!param.name) continue;
-            
+
             const prop = { type: param.type };
             if (param.description) prop.description = param.description;
             if (param.enum) {
                 prop.enum = param.enum.split(',').map(s => s.trim()).filter(s => s);
             }
-            
+
             properties[param.name] = prop;
             if (param.required) required.push(param.name);
         }
-        
+
         const schema = { type: 'object', properties };
         if (required.length > 0) schema.required = required;
-        
+
         return schema;
     }
-    
+
     addParameter() {
         this.currentParams.push({
             name: '',
@@ -4661,7 +4677,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             enum: ''
         });
         this.renderParamsList();
-        
+
         // Focus the new parameter's name input
         setTimeout(() => {
             const items = this.elements.paramsList.querySelectorAll('.param-item');
@@ -4672,21 +4688,21 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             }
         }, 50);
     }
-    
+
     removeParameter(index) {
         this.currentParams.splice(index, 1);
         this.renderParamsList();
     }
-    
+
     renderParamsList() {
         const container = this.elements.paramsList;
         if (!container) return;
-        
+
         // Update count
         if (this.elements.paramCount) {
             this.elements.paramCount.textContent = `(${this.currentParams.length})`;
         }
-        
+
         if (this.currentParams.length === 0) {
             container.innerHTML = `
                 <div class="params-empty">
@@ -4695,7 +4711,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             `;
             return;
         }
-        
+
         container.innerHTML = this.currentParams.map((param, index) => `
             <div class="param-item" data-param-index="${index}">
                 <div class="param-item-header">
@@ -4731,31 +4747,31 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 </div>
             </div>
         `).join('');
-        
+
         // Attach event listeners to parameter items
         this.attachParamListeners();
     }
-    
+
     escapeHtml(str) {
         if (!str) return '';
         return str.replace(/&/g, '&amp;')
-                  .replace(/</g, '&lt;')
-                  .replace(/>/g, '&gt;')
-                  .replace(/"/g, '&quot;')
-                  .replace(/'/g, '&#039;');
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
     }
-    
+
     attachParamListeners() {
         const container = this.elements.paramsList;
         if (!container) return;
-        
+
         container.querySelectorAll('.param-item').forEach((item, index) => {
             // Delete button
             const deleteBtn = item.querySelector('.param-delete-btn');
             if (deleteBtn) {
                 deleteBtn.addEventListener('click', () => this.removeParameter(index));
             }
-            
+
             // Required checkbox
             const requiredCheckbox = item.querySelector('.param-required');
             if (requiredCheckbox) {
@@ -4763,7 +4779,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     this.currentParams[index].required = requiredCheckbox.checked;
                 });
             }
-            
+
             // Name input
             const nameInput = item.querySelector('.param-name');
             if (nameInput) {
@@ -4771,7 +4787,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     this.currentParams[index].name = nameInput.value;
                 });
             }
-            
+
             // Type select
             const typeSelect = item.querySelector('.param-type');
             if (typeSelect) {
@@ -4784,7 +4800,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     }
                 });
             }
-            
+
             // Description input
             const descInput = item.querySelector('.param-description');
             if (descInput) {
@@ -4792,7 +4808,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     this.currentParams[index].description = descInput.value;
                 });
             }
-            
+
             // Enum input
             const enumInput = item.querySelector('.param-enum');
             if (enumInput) {
@@ -4802,33 +4818,33 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             }
         });
     }
-    
+
     closeToolEditor() {
         this.elements.toolEditorModal.style.display = 'none';
         this.editingToolIndex = -1;
     }
-    
+
     saveTool() {
         const name = this.elements.toolName.value.trim();
         const description = this.elements.toolDescription.value.trim();
-        
+
         // Validation
         if (!name) {
             this.showNotification('Function name is required', 'error');
             return;
         }
-        
+
         // Validate function name format
         if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
             this.showNotification('Invalid function name. Use only letters, numbers, and underscores.', 'error');
             return;
         }
-        
+
         if (!description) {
             this.showNotification('Description is required', 'error');
             return;
         }
-        
+
         // Validate parameter names
         for (const param of this.currentParams) {
             if (param.name && !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(param.name)) {
@@ -4836,10 +4852,10 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 return;
             }
         }
-        
+
         // Build parameters from form
         const parameters = this.paramsToJsonSchema();
-        
+
         const tool = {
             type: 'function',
             function: {
@@ -4848,7 +4864,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 parameters: parameters
             }
         };
-        
+
         if (this.editingToolIndex >= 0) {
             // Update existing
             this.tools[this.editingToolIndex] = tool;
@@ -4863,12 +4879,12 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             this.tools.push(tool);
             this.showNotification(`Tool "${name}" added`, 'success');
         }
-        
+
         this.closeToolEditor();
         this.renderToolsList();
         this.updateToolsCountBadge();
     }
-    
+
     deleteTool(index) {
         if (index >= 0 && index < this.tools.length) {
             const name = this.tools[index].function.name;
@@ -4878,10 +4894,10 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             this.showNotification(`Tool "${name}" removed`, 'info');
         }
     }
-    
+
     async clearAllTools() {
         if (this.tools.length === 0) return;
-        
+
         const confirmed = await this.showConfirm({
             title: 'Clear All Tools',
             message: `Remove all ${this.tools.length} tool(s)? This action cannot be undone.`,
@@ -4890,7 +4906,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             icon: '🗑️',
             type: 'danger'
         });
-        
+
         if (confirmed) {
             this.tools = [];
             this.renderToolsList();
@@ -4898,11 +4914,11 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             this.showNotification('All tools cleared', 'info');
         }
     }
-    
+
     renderToolsList() {
         const container = this.elements.toolsList;
         if (!container) return;
-        
+
         if (this.tools.length === 0) {
             container.innerHTML = `
                 <div class="tools-empty-state">
@@ -4911,13 +4927,13 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             `;
             return;
         }
-        
+
         container.innerHTML = this.tools.map((tool, index) => {
             const func = tool.function;
             const params = func.parameters?.properties || {};
             const paramNames = Object.keys(params);
             const requiredParams = func.parameters?.required || [];
-            
+
             return `
                 <div class="tool-item" data-index="${index}">
                     <div class="tool-item-info">
@@ -4937,7 +4953,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             `;
         }).join('');
     }
-    
+
     updateToolsCountBadge() {
         // Update old badge (if still present)
         const badge = this.elements.toolsCountBadge;
@@ -4949,21 +4965,21 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 badge.style.display = 'none';
             }
         }
-        
+
         // Update new toolbar badge
         this.updateToolsBadge();
         // Update modified indicators
         this.updateModifiedIndicators();
     }
-    
+
     async loadToolPreset(presetName) {
         try {
             const response = await fetch('/api/tools/presets');
             const data = await response.json();
-            
+
             if (data.presets && data.presets[presetName]) {
                 const preset = data.presets[presetName];
-                
+
                 // Add tools from preset (avoid duplicates)
                 let added = 0;
                 for (const tool of preset.tools) {
@@ -4973,13 +4989,13 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                         added++;
                     }
                 }
-                
+
                 this.renderToolsList();
                 this.updateToolsCountBadge();
-                
+
                 if (added > 0) {
                     this.showNotification(`Loaded ${preset.name}: ${added} tool${added > 1 ? 's' : ''} added`, 'success');
-                    
+
                     // Auto-set tool choice to "auto" if not already set
                     if (this.elements.toolChoice.value === '') {
                         this.elements.toolChoice.value = 'auto';
@@ -4993,49 +5009,49 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             this.showNotification('Failed to load preset', 'error');
         }
     }
-    
+
     getToolsForRequest() {
         // Return CUSTOM tools array for API request, or null if empty/disabled
         // MCP tools are handled separately via getMCPToolsForRequest()
         // This method is for the Tool Calling panel only
         const toolChoice = this.elements.toolChoice?.value || '';
-        
+
         // Debug logging
         console.log('=== getToolsForRequest (Custom Tools) ===');
         console.log('toolChoice dropdown value:', JSON.stringify(toolChoice));
         console.log('this.tools.length:', this.tools.length);
         console.log('this.tools:', JSON.stringify(this.tools.map(t => t.function?.name)));
-        
+
         // If tool choice is empty (None), don't send tools
         if (toolChoice === '') {
             console.log('Result: tool_choice is empty, returning null');
             return { tools: null, tool_choice: null, parallel_tool_calls: null };
         }
-        
+
         // If tool choice is set but no tools defined, warn the user
         if (this.tools.length === 0) {
             console.warn(`Tool choice "${toolChoice}" selected but no tools defined - ignoring tool settings`);
             this.showNotification('⚠️ Tool choice is set to "Auto" but no tools are defined. Add tools using the + button or presets.', 'warning', 5000);
             return { tools: null, tool_choice: null, parallel_tool_calls: null };
         }
-        
+
         const result = {
             tools: this.tools,
             tool_choice: toolChoice,
             parallel_tool_calls: this.elements.parallelToolCalls?.checked || null
         };
         console.log('Result: returning tools config:', result.tool_choice, 'with', result.tools.length, 'tools');
-        
+
         return result;
     }
-    
+
     /**
      * Detect if text contains malformed tool call patterns
      * This catches cases where vLLM's tool parser failed but still returned content
      */
     detectMalformedToolCall(text) {
         if (!text) return false;
-        
+
         // Common patterns that indicate a failed tool call parse:
         // 1. Hermes format: <tool_call>...</tool_call>
         // 2. Raw JSON with function name/arguments
@@ -5049,24 +5065,24 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             /\{\s*"type"\s*:\s*"function"/,          // Function type declaration
             /<function=/i,                           // Alternative function tag format
         ];
-        
+
         return patterns.some(pattern => pattern.test(text));
     }
-    
+
     formatToolCallMessage(toolCalls) {
         // Format tool calls for display in chat (custom tools - no execution)
         if (!toolCalls || toolCalls.length === 0) return '';
-        
+
         return `
             <div class="tool-calls-container">
                 ${toolCalls.map(tc => {
-                    const func = tc.function || {};
-                    let argsDisplay = func.arguments || '{}';
-                    try {
-                        argsDisplay = JSON.stringify(JSON.parse(func.arguments), null, 2);
-                    } catch (e) {}
-                    
-                    return `
+            const func = tc.function || {};
+            let argsDisplay = func.arguments || '{}';
+            try {
+                argsDisplay = JSON.stringify(JSON.parse(func.arguments), null, 2);
+            } catch (e) {}
+
+            return `
                         <div class="tool-call-content">
                             <div class="tool-call-header">
                                 <span class="tool-icon"><span class="icon-mcp-tools"></span></span>
@@ -5075,20 +5091,20 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                             <div class="tool-call-args">${this.escapeHtml(argsDisplay)}</div>
                         </div>
                     `;
-                }).join('')}
+        }).join('')}
             </div>
         `;
     }
-    
+
     formatMCPToolCallMessage(toolCalls) {
         // Format MCP tool calls with individual Execute/Skip buttons for each tool
         if (!toolCalls || toolCalls.length === 0) return '';
-        
+
         // Store pending MCP tool calls for execution
         this._pendingMCPToolCalls = [...toolCalls];
         this._mcpToolResults = [];
         this._mcpToolsProcessed = 0;
-        
+
         return `
             <div class="mcp-tool-calls-container">
                 <div class="mcp-tool-calls-header">
@@ -5096,13 +5112,13 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     <span>MCP Tool Call${toolCalls.length > 1 ? 's' : ''} - Review Each Tool</span>
                 </div>
                 ${toolCalls.map((tc, index) => {
-                    const func = tc.function || {};
-                    let argsDisplay = func.arguments || '{}';
-                    try {
-                        argsDisplay = JSON.stringify(JSON.parse(func.arguments), null, 2);
-                    } catch (e) {}
-                    
-                    return `
+            const func = tc.function || {};
+            let argsDisplay = func.arguments || '{}';
+            try {
+                argsDisplay = JSON.stringify(JSON.parse(func.arguments), null, 2);
+            } catch (e) {}
+
+            return `
                         <div class="mcp-tool-call-item" data-tool-index="${index}" data-tool-id="${tc.id}">
                             <div class="mcp-tool-call-header">
                                 <span class="tool-name">${this.escapeHtml(func.name || 'unknown')}</span>
@@ -5123,7 +5139,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                             <div class="mcp-tool-result" style="display: none;"></div>
                         </div>
                     `;
-                }).join('')}
+        }).join('')}
                 <div class="mcp-tool-continue" style="display: none;">
                     <button class="btn btn-primary" onclick="window.vllmUI.continueMCPConversation()">
                         Continue Conversation
@@ -5135,13 +5151,13 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             </div>
         `;
     }
-    
+
     async executeSingleMCPTool(index) {
         if (!this._pendingMCPToolCalls || !this._pendingMCPToolCalls[index]) {
             this.showNotification('Tool not found', 'warning');
             return;
         }
-        
+
         const tc = this._pendingMCPToolCalls[index];
         const func = tc.function || {};
         const toolName = func.name;
@@ -5152,11 +5168,11 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         const statusEl = itemEl?.querySelector('.tool-status');
         const resultEl = itemEl?.querySelector('.mcp-tool-result');
         const actionsEl = itemEl?.querySelector('.mcp-tool-actions-individual');
-        
+
         // Validate tool exists in MCP tools (check ALL tools, not just enabled ones)
         const allMcpTools = this.mcpTools || [];
         const toolExists = allMcpTools.some(t => t.function?.name === toolName);
-        
+
         if (!toolExists) {
             // Tool doesn't exist - model hallucinated the tool name
             if (actionsEl) actionsEl.style.display = 'none';
@@ -5175,28 +5191,28 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     </div>
                 `;
             }
-            
+
             // Add error result
             this._mcpToolResults.push({
                 tool_call_id: tc.id,
                 role: 'tool',
                 content: `Error: Tool "${toolName}" does not exist. Available tools: ${allMcpTools.map(t => t.function?.name).join(', ')}`
             });
-            
+
             this._mcpToolsProcessed++;
             this.checkMCPToolsComplete();
             return;
         }
-        
+
         // Hide action buttons for this tool
         if (actionsEl) actionsEl.style.display = 'none';
-        
+
         // Update status to executing
         if (statusEl) {
             statusEl.textContent = 'Executing...';
             statusEl.className = 'tool-status executing';
         }
-        
+
         try {
             // Parse arguments
             let args = {};
@@ -5205,9 +5221,9 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             } catch (e) {
                 console.error('Failed to parse tool arguments:', e);
             }
-            
+
             console.log(`🔧 Executing MCP tool: ${func.name}`, args);
-            
+
             // Call MCP backend
             const response = await fetch('/api/mcp/call', {
                 method: 'POST',
@@ -5217,15 +5233,15 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                     arguments: args
                 })
             });
-            
+
             if (!response.ok) {
                 const error = await response.json();
                 throw new Error(error.detail || 'Tool execution failed');
             }
-            
+
             const result = await response.json();
             console.log(`✅ Tool result for ${func.name}:`, result);
-            
+
             // Update UI
             if (statusEl) {
                 statusEl.textContent = 'Executed';
@@ -5235,7 +5251,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 resultEl.style.display = 'block';
                 resultEl.innerHTML = `<details open><summary>Result</summary><pre>${this.escapeHtml(JSON.stringify(result.result, null, 2))}</pre></details>`;
             }
-            
+
             // Store result for chat continuation
             this._mcpToolResults.push({
                 tool_call_id: tc.id,
@@ -5243,12 +5259,12 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 name: toolName,  // Include tool name for proper message format
                 content: typeof result.result === 'string' ? result.result : JSON.stringify(result.result)
             });
-            
+
             console.log('✅ Tool result stored:', { tool_call_id: tc.id, name: toolName });
-            
+
         } catch (error) {
             console.error(`❌ Tool execution failed for ${func.name}:`, error);
-            
+
             if (statusEl) {
                 statusEl.textContent = 'Failed';
                 statusEl.className = 'tool-status error';
@@ -5257,7 +5273,7 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 resultEl.style.display = 'block';
                 resultEl.innerHTML = `<div class="tool-error">Error: ${this.escapeHtml(error.message)}</div>`;
             }
-            
+
             // Still add error result so conversation can continue
             this._mcpToolResults.push({
                 tool_call_id: tc.id,
@@ -5266,17 +5282,17 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 content: `Error: ${error.message}`
             });
         }
-        
+
         // Mark this tool as processed
         this._mcpToolsProcessed++;
         this.checkMCPToolsComplete();
     }
-    
+
     skipSingleMCPTool(index) {
         if (!this._pendingMCPToolCalls || !this._pendingMCPToolCalls[index]) {
             return;
         }
-        
+
         const tc = this._pendingMCPToolCalls[index];
         const func = tc.function || {};
         // Get the LAST (most recent) tool calls container to avoid targeting old ones
@@ -5285,10 +5301,10 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
         const itemEl = container?.querySelector(`[data-tool-index="${index}"]`);
         const statusEl = itemEl?.querySelector('.tool-status');
         const actionsEl = itemEl?.querySelector('.mcp-tool-actions-individual');
-        
+
         // Hide action buttons for this tool
         if (actionsEl) actionsEl.style.display = 'none';
-        
+
         // Update status
         if (statusEl) {
             statusEl.textContent = 'Skipped';
@@ -5300,19 +5316,19 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             name: func.name,  // Include tool name for proper message format
             content: 'Tool execution was skipped by user.'
         });
-        
+
         // Mark this tool as processed
         this._mcpToolsProcessed++;
         this.checkMCPToolsComplete();
     }
-    
+
     checkMCPToolsComplete() {
         // Check if all tools have been processed (executed or skipped)
         if (!this._pendingMCPToolCalls) return;
-        
+
         const totalTools = this._pendingMCPToolCalls.length;
         const processed = this._mcpToolsProcessed || 0;
-        
+
         if (processed >= totalTools) {
             // All tools processed - show continue options
             // Get the LAST (most recent) tool calls container
@@ -5320,63 +5336,63 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             const container = containers[containers.length - 1];
             const header = container?.querySelector('.mcp-tool-calls-header span:last-child');
             const continueDiv = container?.querySelector('.mcp-tool-continue');
-            
+
             if (header) header.textContent = `All ${totalTools} tool${totalTools > 1 ? 's' : ''} reviewed`;
             if (continueDiv) continueDiv.style.display = 'flex';
-            
+
             // Clear pending
             this._pendingMCPToolCalls = null;
         }
     }
-    
+
     async continueMCPConversation() {
         // Phase 3: Continue conversation with tool results
         if (!this._mcpToolResults || this._mcpToolResults.length === 0) {
             this.showNotification('No tool results to continue with', 'warning');
             return;
         }
-        
+
         // Add tool results to chat history
         for (const result of this._mcpToolResults) {
             this.chatHistory.push(result);
         }
-        
+
         // Clear stored results
         this._mcpToolResults = null;
-        
+
         // Trigger a new message to continue the conversation
         // We use a special flag to indicate this is a continuation
         this._mcpContinuation = true;
-        
+
         // Re-enable send button and trigger send with empty message
         this.elements.sendBtn.disabled = false;
         this.elements.sendBtn.textContent = 'Send';
-        
+
         // Send continuation request
         await this.sendMCPContinuation();
     }
-    
+
     async sendMCPContinuation() {
         // Send a follow-up request with tool results already in history
         this.elements.sendBtn.disabled = true;
         this.elements.sendBtn.textContent = 'Generating...';
-        
+
         const assistantMessageDiv = this.addChatMessage('assistant', '▌');
         const textSpan = assistantMessageDiv.querySelector('.message-text');
-        
+
         try {
             const systemPrompt = this.elements.systemPrompt.value.trim();
             let messagesToSend = [...this.chatHistory];
-            
+
             if (systemPrompt) {
                 messagesToSend = [
                     {role: 'system', content: systemPrompt},
                     ...this.chatHistory
                 ];
             }
-            
+
             console.log('📤 Sending MCP continuation with messages:', JSON.stringify(messagesToSend, null, 2));
-            
+
             // Don't send tools in continuation - force text response
             // This prevents the model from calling the same tool again in a loop
             const requestBody = {
@@ -5385,36 +5401,36 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 max_tokens: parseInt(this.elements.maxTokens.value),
                 stream: true  // Use streaming since no tools
             };
-            
+
             console.log('📤 Continuation request (no tools, streaming):', requestBody);
-            
+
             const response = await fetch('/api/chat', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(requestBody)
             });
-            
+
             if (!response.ok) {
                 throw new Error(await response.text() || 'Failed to continue conversation');
             }
-            
+
             // Check content type to determine response format
             const contentType = response.headers.get('content-type') || '';
-            
+
             if (contentType.includes('application/json')) {
                 // Non-streaming JSON response
                 const jsonResponse = await response.json();
                 console.log('📤 MCP continuation response:', jsonResponse);
-                
+
                 if (jsonResponse.choices && jsonResponse.choices.length > 0) {
                     const message = jsonResponse.choices[0].message;
-                    
+
                     // Display text content if present
                     if (message.content) {
                         textSpan.textContent = message.content;
                         this.chatHistory.push({ role: 'assistant', content: message.content });
                     }
-                    
+
                     // If model STILL wants to call tools, show them (but this shouldn't happen)
                     if (message.tool_calls && message.tool_calls.length > 0) {
                         console.warn('⚠️ Model still requesting tool calls after continuation');
@@ -5431,19 +5447,19 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                 const reader = response.body.getReader();
                 const decoder = new TextDecoder();
                 let fullText = '';
-                
+
                 while (true) {
                     const { done, value } = await reader.read();
                     if (done) break;
-                    
+
                     const chunk = decoder.decode(value, { stream: true });
                     const lines = chunk.split('\n');
-                    
+
                     for (const line of lines) {
                         if (line.startsWith('data: ')) {
                             const data = line.slice(6);
                             if (data === '[DONE]') continue;
-                            
+
                             try {
                                 const parsed = JSON.parse(data);
                                 const content = parsed.choices?.[0]?.delta?.content || '';
@@ -5457,14 +5473,14 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
                         }
                     }
                 }
-                
+
                 if (fullText) {
                     this.chatHistory.push({ role: 'assistant', content: fullText });
                 } else {
                     textSpan.textContent = 'No response from model';
                 }
             }
-            
+
         } catch (error) {
             textSpan.textContent = `Error: ${error.message}`;
             assistantMessageDiv.classList.add('error');
@@ -5474,20 +5490,20 @@ ${fullText.substring(0, 200)}${fullText.length > 200 ? '...' : ''}`;
             this._mcpContinuation = false;
         }
     }
-    
+
     endMCPConversation() {
         // User chose not to continue after tool execution
         this._mcpToolResults = null;
         this.showNotification('Conversation ended', 'info');
     }
-    
+
     escapeHtml(text) {
         if (!text) return '';
         const div = document.createElement('div');
         div.textContent = text;
         return div.innerHTML;
     }
-    
+
     // ============================================
     // MCP Module - Methods injected from modules/mcp.js
     // ============================================
@@ -5524,10 +5540,10 @@ document.head.appendChild(style);
 // Initialize the app when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
     window.vllmUI = new VLLMWebUI();
-    
+
     // Load saved layout preferences
     window.vllmUI.loadLayoutPreferences();
-    
+
     // Add cleanup on page unload
     window.addEventListener('beforeunload', () => {
         if (window.vllmUI) {


### PR DESCRIPTION
Clicking the "Start Server" button multiple times before the first request completes causes container name conflicts:

`Error: Conflict. The container name "/vllm-service" is already in use`

Add `serverStarting` flag to prevent duplicate start requests when clicking the Start Server button multiple times (or more than once).

Changes:
- Add serverStarting property to track when server start is in progress
- Add guard clause in startServer() to reject clicks while starting
- Show warning notification when attempting duplicate starts
- Update pollStatus() to respect starting flag and not re-enable button
- Clear flag on success (via pollStatus) or failure (in catch block)

This prevents container name conflicts that occur when multiple /api/start requests are sent before the first one completes.

<img width="1197" height="388" alt="Screenshot 2026-01-09 at 01 21 47" src="https://github.com/user-attachments/assets/1e3bd350-bc4e-4435-9b2d-dcf88028249d" />

---
<img width="1710" height="432" alt="Screenshot 2026-01-09 at 02 00 09" src="https://github.com/user-attachments/assets/84ee7e03-05b4-4e85-9d57-d4e7751dc65f" />

- [2:00:07 AM] ❌ Failed to start server: Failed to start container: docker: Error response from daemon: Conflict. The container name "/vllm-service" is already in use by container "eb7af4231dbb85254bb3319b18914ebda2141d641558e673bcb1eefb014ef19d". You have to remove (or rename) that container to be able to reuse that name.

---
<img width="1710" height="472" alt="Screenshot 2026-01-09 at 02 00 21" src="https://github.com/user-attachments/assets/d825956a-40d9-4ef0-8f0f-fb4322d7f6fe" />

