### PR TITLE
feat: Add Jetson unified memory and temperature support for GPU status API

### DIFF
--- a/vllm_playground/app.py
+++ b/vllm_playground/app.py
@@ -1252,6 +1252,72 @@ def is_jetson_device(gpu_name: str) -> bool:
     return any(keyword in name_lower for keyword in jetson_keywords)
 
 
+def get_jetson_temperature():
+    """
+    Get temperature for Jetson devices from thermal zones.
+    Jetson uses Linux thermal zones instead of nvidia-smi for temperature.
+    
+    Priority order:
+    1. tj-thermal (Thermal Junction - most accurate)
+    2. gpu-thermal
+    3. Any available thermal zone
+    
+    Returns temperature in Celsius or None if not available.
+    """
+    thermal_base = '/sys/devices/virtual/thermal'
+    preferred_zones = ['tj-thermal', 'gpu-thermal']
+    
+    try:
+        import os
+        
+        # First, try preferred thermal zones
+        for zone_name in preferred_zones:
+            for zone_dir in os.listdir(thermal_base):
+                if zone_dir.startswith('thermal_zone'):
+                    zone_path = os.path.join(thermal_base, zone_dir)
+                    type_path = os.path.join(zone_path, 'type')
+                    temp_path = os.path.join(zone_path, 'temp')
+                    
+                    try:
+                        with open(type_path, 'r') as f:
+                            zone_type = f.read().strip()
+                        
+                        if zone_type == zone_name:
+                            with open(temp_path, 'r') as f:
+                                # Temperature is in milli-Celsius
+                                temp_mc = int(f.read().strip())
+                                temp_c = temp_mc // 1000
+                                logger.debug(f"Jetson temperature from {zone_name}: {temp_c}°C")
+                                return temp_c
+                    except (IOError, ValueError):
+                        continue
+        
+        # Fallback: try any thermal zone with 'gpu' in name
+        for zone_dir in os.listdir(thermal_base):
+            if zone_dir.startswith('thermal_zone'):
+                zone_path = os.path.join(thermal_base, zone_dir)
+                type_path = os.path.join(zone_path, 'type')
+                temp_path = os.path.join(zone_path, 'temp')
+                
+                try:
+                    with open(type_path, 'r') as f:
+                        zone_type = f.read().strip()
+                    
+                    if 'gpu' in zone_type.lower() or 'tj' in zone_type.lower():
+                        with open(temp_path, 'r') as f:
+                            temp_mc = int(f.read().strip())
+                            temp_c = temp_mc // 1000
+                            logger.debug(f"Jetson temperature from {zone_type}: {temp_c}°C")
+                            return temp_c
+                except (IOError, ValueError):
+                    continue
+                    
+    except Exception as e:
+        logger.warning(f"Failed to read Jetson temperature: {e}")
+    
+    return None
+
+
 @app.get("/api/gpu-status")
 async def get_gpu_status():
     """
@@ -1283,12 +1349,22 @@ async def get_gpu_status():
                     
                     # Check if this is a Jetson device with unified memory
                     is_jetson = is_jetson_device(gpu_name)
-                    if is_jetson and memory_total == 0:
+                    temperature = safe_int(parts[6], 0)
+                    
+                    if is_jetson:
                         # Jetson uses unified memory, get from /proc/meminfo
-                        unified_mem = get_jetson_unified_memory()
-                        if unified_mem:
-                            memory_used, memory_total, memory_free = unified_mem
-                            logger.info(f"Jetson unified memory: {memory_used}MB used, {memory_total}MB total, {memory_free}MB free")
+                        if memory_total == 0:
+                            unified_mem = get_jetson_unified_memory()
+                            if unified_mem:
+                                memory_used, memory_total, memory_free = unified_mem
+                                logger.info(f"Jetson unified memory: {memory_used}MB used, {memory_total}MB total, {memory_free}MB free")
+                        
+                        # Jetson temperature from thermal zones (nvidia-smi returns [N/A])
+                        if temperature == 0:
+                            jetson_temp = get_jetson_temperature()
+                            if jetson_temp is not None:
+                                temperature = jetson_temp
+                                logger.info(f"Jetson temperature from thermal zone: {temperature}°C")
                     
                     gpu_info.append({
                         "index": safe_int(parts[0], 0),
@@ -1297,7 +1373,7 @@ async def get_gpu_status():
                         "memory_total": memory_total,
                         "memory_free": memory_free,
                         "utilization": safe_int(parts[5], 0),
-                        "temperature": safe_int(parts[6], 0),
+                        "temperature": temperature,
                         "is_jetson": is_jetson,
                         "unified_memory": is_jetson  # Jetson uses unified CPU/GPU memory
                     })


### PR DESCRIPTION
##  Apology

Sorry, in my previous PR I forgot to fix the issue where Jetson Orin/Thor devices show 0.0GB available memory and 0°C temperature in the GPU status display.

##  Description

This PR adds proper unified memory and temperature support for NVIDIA Jetson devices (Thor, Orin, Xavier, Nano, TX1, TX2, etc.).

### Problem

On Jetson devices, `nvidia-smi --query-gpu` returns `[N/A]` for memory and temperature fields because:
1. Jetson uses **unified memory** shared between CPU and GPU
2. Jetson uses **Linux thermal zones** instead of nvidia-smi for temperature

This caused the GPU status API to display:
```
NVIDIA Thor
GPU 0
Memory: 0.0GB free / 0.0GB
Temperature: 0°C
```

### Solution

**Memory:**
- Added `get_jetson_unified_memory()` to read memory from `/proc/meminfo`
- Added `is_jetson_device()` to detect Jetson devices by GPU name

**Temperature:**
- Added `get_jetson_temperature()` to read from Linux thermal zones
- Priority order: `tj-thermal` (Thermal Junction) > `gpu-thermal` > other zones
- Temperature values are in milli-Celsius, converted to Celsius

### Supported Devices

| Device | Detection Keyword |
|--------|------------------|
| Jetson Thor | `thor` |
| Jetson AGX Orin / Orin Nano / Orin NX | `orin` |
| Jetson AGX Xavier / Xavier NX | `xavier` |
| Jetson Nano | `nano` |
| Jetson TX1/TX2 | `tx1`, `tx2` |

### Testing

<img width="336" height="256" alt="截屏2026-01-09 11 56 50" src="https://github.com/user-attachments/assets/219f54c3-9f2c-4e5f-bb76-5ac4332d7f56" />

Tested on NVIDIA Jetson Thor with CUDA 13.0:

```bash
$ curl -s http://localhost:7860/api/gpu-status
{
  "gpu_available": true,
  "gpu_count": 1,
  "gpus": [{
    "index": 0,
    "name": "NVIDIA Thor",
    "memory_used": 103444,
    "memory_total": 125772,
    "memory_free": 22328,
    "utilization": 0,
    "temperature": 43,
    "is_jetson": true,
    "unified_memory": true
  }]
}
```

##  Files Changed

- `app.py` - Added Jetson unified memory and temperature support
- `vllm_playground/app.py` - Added Jetson unified memory and temperature support (package version)
```